### PR TITLE
Add ProfileDescription to ImageService2

### DIFF
--- a/local_build.sh
+++ b/local_build.sh
@@ -1,0 +1,15 @@
+#! /bin/bash
+
+VERSION=1.0.0
+while getopts v: flag
+do
+    case "${flag}" in
+        v) VERSION=${OPTARG};;
+    esac
+done
+
+cd ./src/IIIF
+
+dotnet build IIIF.sln --configuration Release --no-restore
+dotnet test --configuration=Release --no-restore --no-build --verbosity normal
+dotnet pack ./IIIF/IIIF.csproj --configuration Release -p:Version=$VERSION --no-restore --no-build

--- a/readme.md
+++ b/readme.md
@@ -16,3 +16,15 @@ The `.Serialisation` namespace contains a number of custom `JsonConverter` imple
 * `[RequiredOutput]` - used on `IEnumerable<T>` properties. Will output `[]` if collection is empty (default is to omit empty lists).
 
 > NOTE: Deserialisation of models is currently not supported.
+
+## Local Build
+
+The `local_build.sh` bash script will build/test/pack for ease of testing.
+
+```bash
+# build version 1.0.0
+$ bash build.sh
+
+# build version 1.2.3
+$ bash build.sh -v 1.2.3
+```

--- a/src/IIIF/IIIF.Tests/IIIF.Tests.csproj
+++ b/src/IIIF/IIIF.Tests/IIIF.Tests.csproj
@@ -26,7 +26,6 @@
 
     <ItemGroup>
       <Folder Include="ImageApi" />
-      <Folder Include="Serialisation" />
     </ItemGroup>
 
 </Project>

--- a/src/IIIF/IIIF.Tests/Serialisation/ImageService2SerialiserTests.cs
+++ b/src/IIIF/IIIF.Tests/Serialisation/ImageService2SerialiserTests.cs
@@ -1,0 +1,94 @@
+﻿using System.Collections.Generic;
+using FluentAssertions;
+using IIIF.ImageApi.Service;
+using IIIF.Serialisation;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using Xunit;
+
+namespace IIIF.Tests.Serialisation
+{
+    public class ImageService2SerialiserTests
+    {
+        private readonly JsonSerializerSettings jsonSerializerSettings;
+
+        public ImageService2SerialiserTests()
+        {
+            // NOTE: Using JsonSerializerSettings to facilitate testing as it makes it a LOT easier
+            jsonSerializerSettings = new JsonSerializerSettings
+            {
+                NullValueHandling = NullValueHandling.Ignore,
+                ContractResolver = new CamelCasePropertyNamesContractResolver(),
+                Converters = new List<JsonConverter> { new ImageService2Serialiser() }
+            };
+        }
+
+        [Fact]
+        public void WriteJson_OutputsExpected_IfNoProfileOrProfileDescription()
+        {
+            // Arrange
+            var imageService = new ImageService2 { Id = "foo" };
+            const string expected = "{\"@id\":\"foo\",\"@type\":\"ImageService2\",\"width\":0,\"height\":0}";
+            
+            // Act
+            var result = JsonConvert.SerializeObject(imageService, jsonSerializerSettings);
+            
+            // Assert
+            result.Should().Be(expected);
+        }
+        
+        [Fact]
+        public void WriteJson_OutputsExpected_ProfileOnly()
+        {
+            // Arrange
+            var imageService = new ImageService2 { Id = "foo", Profile = "bar" };
+            const string expected =
+                "{\"@id\":\"foo\",\"@type\":\"ImageService2\",\"profile\":\"bar\",\"width\":0,\"height\":0}";
+            
+            // Act
+            var result = JsonConvert.SerializeObject(imageService, jsonSerializerSettings);
+            
+            // Assert
+            result.Should().Be(expected);
+        }
+        
+        [Fact]
+        public void WriteJson_OutputsExpected_ProfileDescriptionOnly()
+        {
+            // Arrange
+            var imageService = new ImageService2
+            {
+                Id = "foo",
+                ProfileDescription = new ProfileDescription { MaxHeight = 10, MaxWidth = 20 },
+            };
+            const string expected =
+                "{\"@id\":\"foo\",\"@type\":\"ImageService2\",\"width\":0,\"height\":0,\"profile\":{\"maxHeight\":10,\"maxWidth\":20}}";
+            
+            // Act
+            var result = JsonConvert.SerializeObject(imageService, jsonSerializerSettings);
+            
+            // Assert
+            result.Should().Be(expected);
+        }
+        
+        [Fact]
+        public void WriteJson_OutputsExpected_ProfileAndProfileDescription()
+        {
+            // Arrange
+            var imageService = new ImageService2
+            {
+                Id = "foo",
+                Profile = "bar",
+                ProfileDescription = new ProfileDescription { MaxHeight = 10, MaxWidth = 20 },
+            };
+            const string expected =
+                "{\"@id\":\"foo\",\"@type\":\"ImageService2\",\"profile\":[\"bar\",{\"maxHeight\":10,\"maxWidth\":20}],\"width\":0,\"height\":0}";
+            
+            // Act
+            var result = JsonConvert.SerializeObject(imageService, jsonSerializerSettings);
+            
+            // Assert
+            result.Should().Be(expected);
+        }
+    }
+}

--- a/src/IIIF/IIIF/ImageApi/Service/ImageService2.cs
+++ b/src/IIIF/IIIF/ImageApi/Service/ImageService2.cs
@@ -18,6 +18,9 @@ namespace IIIF.ImageApi.Service
         
         [JsonProperty(PropertyName = "protocol", Order = 10)]
         public string? Protocol { get; set; }
+        
+        [JsonIgnore]
+        public ProfileDescription ProfileDescription { get; set; }
 
         [JsonProperty(Order = 11)]
         public int Width { get; set; }

--- a/src/IIIF/IIIF/ImageApi/Service/ProfileDescription.cs
+++ b/src/IIIF/IIIF/ImageApi/Service/ProfileDescription.cs
@@ -1,0 +1,61 @@
+﻿using Newtonsoft.Json;
+
+namespace IIIF.ImageApi.Service
+{
+    /// <summary>
+    /// Specifies additional features that are supported for the image.
+    /// </summary>
+    /// <see cref="https://iiif.io/api/image/2.1/#profile-description"/>
+    public class ProfileDescription : JsonLdBase
+    {
+        [JsonProperty(PropertyName = "@id", Order = 2)]
+        public string? Id { get; set; }
+
+        [JsonProperty(PropertyName = "@type", Order = 3)]
+        public string? Type { get; set; }
+        
+        /// <summary>
+        /// The set of image format parameter values available for the image.
+        /// If not specified then clients should assume only formats declared in the compliance level document.
+        /// </summary>
+        [JsonProperty(Order = 4, PropertyName = "formats")]
+        public string[]? Formats { get; set; }
+        
+        /// <summary>
+        /// The maximum area in pixels supported for this image.
+        /// Requests for images sizes with width*height greater than this may not be supported.
+        /// </summary>
+        [JsonProperty(Order = 5, PropertyName = "maxArea")]
+        public int? MaxArea { get; set; }
+        
+        /// <summary>
+        /// The maximum height in pixels supported for this image.
+        /// Requests for images sizes with height greater than this may not be supported.
+        /// If maxWidth is specified and maxHeight is not, then clients should infer that maxHeight = maxWidth.
+        /// </summary>
+        [JsonProperty(Order = 6, PropertyName = "maxHeight")]
+        public int? MaxHeight { get; set; }
+        
+        /// <summary>
+        /// The maximum width in pixels supported for this image.
+        /// Requests for images sizes with width greater than this may not be supported.
+        /// Must be specified if maxHeight is specified.
+        /// </summary>
+        [JsonProperty(Order = 7, PropertyName = "maxWidth")]
+        public int? MaxWidth { get; set; }
+        
+        /// <summary>
+        /// The set of image quality parameter values available for the image.
+        /// If not specified then clients should assume only qualities declared in the compliance level document.
+        /// </summary>
+        [JsonProperty(Order = 8, PropertyName = "qualities")]
+        public string[]? Qualities { get; set; }
+        
+        /// <summary>
+        /// The set of features supported for the image.
+        /// If not specified then clients should assume only features declared in the compliance level document.
+        /// </summary>
+        [JsonProperty(Order = 9, PropertyName = "supports")]
+        public string[]? Supports { get; set; }
+    }
+}

--- a/src/IIIF/IIIF/Serialisation/IIIFSerialiserX.cs
+++ b/src/IIIF/IIIF/Serialisation/IIIFSerialiserX.cs
@@ -16,10 +16,10 @@ namespace IIIF.Serialisation
             Converters = new List<JsonConverter>
             {
                 new SizeConverter(), new StringArrayConverter(), new ServiceReferenceConverter(),
-                new ThumbnailConverter()
+                new ThumbnailConverter(), new ImageService2Serialiser()
             }
         };
-        
+
         /// <summary>
         /// Serialise specified iiif resource to json string.
         /// </summary>

--- a/src/IIIF/IIIF/Serialisation/ImageService2Serialiser.cs
+++ b/src/IIIF/IIIF/Serialisation/ImageService2Serialiser.cs
@@ -1,0 +1,41 @@
+﻿using IIIF.ImageApi.Service;
+using IIIF.Presentation.V2.Serialisation;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace IIIF.Serialisation
+{
+    /// <summary>
+    /// Converter for <see cref="ImageService2"/> object, serialises Profile and ProfileDescription into single
+    /// "profile" property.
+    /// </summary>
+    public class ImageService2Serialiser : WriteOnlyConverter<ImageService2>
+    {
+        public override void WriteJson(JsonWriter writer, ImageService2? value, JsonSerializer serializer)
+        {
+            // Create a copy to avoid circular reference issue bombing out
+            var customSerializer = serializer.CreateCopy(converter => converter is not ImageService2Serialiser);
+            if (value?.ProfileDescription == null) 
+            {
+                // If ProfileDescription is null then no special handling required
+                customSerializer.Serialize(writer, value);
+                return;
+            }
+
+            var imageService = JObject.FromObject(value, customSerializer);
+            imageService["profile"] = GetProfileElement(value, customSerializer);
+            imageService.WriteTo(writer);
+        }
+
+        private static JToken GetProfileElement(ImageService2? value, JsonSerializer serializer)
+        {
+            var profileDescription = JToken.FromObject(value.ProfileDescription, serializer);
+
+            var newProfile = string.IsNullOrEmpty(value.Profile)
+                ? new JProperty("property", profileDescription)
+                : new JProperty("property", value.Profile, profileDescription);
+
+            return newProfile.Value;
+        }
+    }
+}

--- a/src/IIIF/IIIF/Serialisation/JsonSerializerExtensions.cs
+++ b/src/IIIF/IIIF/Serialisation/JsonSerializerExtensions.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Linq;
+using Newtonsoft.Json;
+
+namespace IIIF.Serialisation
+{
+    internal static class JsonSerializerExtensions
+    {
+        /// <summary>
+        /// Create a copy of <see cref="JsonSerializer"/>, filtering Converters array
+        /// </summary>
+        /// <param name="serializer">JsonSerializer to copy.</param>
+        /// <param name="converterFilter">Predicate to filter JsonConverters - if true then converter copied</param>
+        /// <returns>New JsonSerializer instance</returns>
+        /// <remarks>Based on https://stackoverflow.com/a/38230327/83096</remarks>
+        public static JsonSerializer CreateCopy(this JsonSerializer serializer, Func<JsonConverter, bool> converterFilter)
+        {
+            var copiedSerializer = new JsonSerializer
+            {
+                Context = serializer.Context,
+                Culture = serializer.Culture,
+                ContractResolver = serializer.ContractResolver,
+                ConstructorHandling = serializer.ConstructorHandling,
+                CheckAdditionalContent = serializer.CheckAdditionalContent,
+                DateFormatHandling = serializer.DateFormatHandling,
+                DateFormatString = serializer.DateFormatString,
+                DateParseHandling = serializer.DateParseHandling,
+                DateTimeZoneHandling = serializer.DateTimeZoneHandling,
+                DefaultValueHandling = serializer.DefaultValueHandling,
+                EqualityComparer = serializer.EqualityComparer,
+                FloatFormatHandling = serializer.FloatFormatHandling,
+                Formatting = serializer.Formatting,
+                FloatParseHandling = serializer.FloatParseHandling,
+                MaxDepth = serializer.MaxDepth,
+                MetadataPropertyHandling = serializer.MetadataPropertyHandling,
+                MissingMemberHandling = serializer.MissingMemberHandling,
+                NullValueHandling = serializer.NullValueHandling,
+                ObjectCreationHandling = serializer.ObjectCreationHandling,
+                PreserveReferencesHandling = serializer.PreserveReferencesHandling,
+                ReferenceResolver = serializer.ReferenceResolver,
+                ReferenceLoopHandling = serializer.ReferenceLoopHandling,
+                StringEscapeHandling = serializer.StringEscapeHandling,
+                TraceWriter = serializer.TraceWriter,
+                TypeNameHandling = serializer.TypeNameHandling,
+                SerializationBinder = serializer.SerializationBinder,
+                TypeNameAssemblyFormatHandling = serializer.TypeNameAssemblyFormatHandling
+            }; 
+            
+            foreach (var converter in serializer.Converters.Where(c => converterFilter(c)))
+            {
+                copiedSerializer.Converters.Add(converter);
+            }
+            return copiedSerializer;
+        }
+    }
+}


### PR DESCRIPTION
Fix for #4 - current "Profile" is on base-class and is a string.

ImageService2 can handle a more complex "Profile" type detailing description. This PR adds "ProfileDescription" property and JsonConverter to combine "Profile" and "ProfileDescription" when serialising.

e.g.
```
// profile only
var imageService = new ImageService2 { Profile = "http://iiif.io/api/image/2/level0.json" };

// outputs as
{
  "@id": "my-id",
  "profile": "http://iiif.io/api/image/2/level0.json"
}

// profile + description
var imageService = new ImageService2 { 
  Profile = "http://iiif.io/api/image/2/level0.json" 
  ProfileDescription = new ProfileDescription
                {
                    Formats = new[] { "jpg" },
                    Qualities = new[] { "color" },
                    Supports = new[] { "sizeByWhListed" }
                }
};

// outputs as
{
  "@id": "my-id",
  "profile": [
    "http://iiif.io/api/image/2/level0.json",
    {
      "formats": ["jpg"],
      "qualities": ["color"],
      "supports": ["sizeByWhListed"],
    }
  ]
}
```