### PR TITLE
Add accessTokenResponse properties

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -23,8 +23,8 @@ The `local_build.sh` bash script will build/test/pack for ease of testing.
 
 ```bash
 # build version 1.0.0
-$ bash build.sh
+$ bash local_build.sh
 
 # build version 1.2.3
-$ bash build.sh -v 1.2.3
+$ bash local_build.sh -v 1.2.3
 ```

--- a/src/IIIF/IIIF.Tests/Auth/V1/AccessTokenService/AccessTokenErrorTests.cs
+++ b/src/IIIF/IIIF.Tests/Auth/V1/AccessTokenService/AccessTokenErrorTests.cs
@@ -1,0 +1,30 @@
+﻿using FluentAssertions;
+using IIIF.Auth.V1.AccessTokenService;
+using Xunit;
+
+namespace IIIF.Tests.Auth.V1.AccessTokenService
+{
+    public class AccessTokenErrorTests
+    {
+        [Theory]
+        [InlineData(AccessTokenErrorConditions.InvalidRequest,
+            "The service could not process the information sent in the body of the request.")]
+        [InlineData(AccessTokenErrorConditions.MissingCredentials,
+            "The request did not have the credentials required.")]
+        [InlineData(AccessTokenErrorConditions.InvalidCredentials,
+            "The request had credentials that are not valid for the service.")]
+        [InlineData(AccessTokenErrorConditions.InvalidOrigin,
+            "The request came from a different origin than that specified in the access cookie service request, or an origin that the server rejects for other reasons.")]
+        [InlineData(AccessTokenErrorConditions.Unavailable,
+            "The request could not be fulfilled for reasons other than those listed above, such as scheduled maintenance.")]
+        public void Ctor_ErrorOnly_UsesDefaultDescription(AccessTokenErrorConditions error, string description)
+        {
+            // Arrange
+            var accessTokenError = new AccessTokenError(error);
+
+            // Assert
+            accessTokenError.Error.Should().Be(error);
+            accessTokenError.Description.Should().Be(description);
+        }
+    }
+}

--- a/src/IIIF/IIIF.Tests/Auth/V1/AccessTokenService/AccessTokenResponseTests.cs
+++ b/src/IIIF/IIIF.Tests/Auth/V1/AccessTokenService/AccessTokenResponseTests.cs
@@ -1,0 +1,41 @@
+﻿using FluentAssertions;
+using IIIF.Auth.V1.AccessTokenService;
+using IIIF.Serialisation;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace IIIF.Tests.Auth.V1.AccessTokenService
+{
+    public class AccessTokenResponseTests
+    {
+        private readonly JsonSerializerSettings jsonSerializerSettings;
+
+        public AccessTokenResponseTests()
+        {
+            // NOTE: Using JsonSerializerSettings to facilitate testing as it makes it a LOT easier
+            jsonSerializerSettings = new JsonSerializerSettings
+            {
+                NullValueHandling = NullValueHandling.Ignore,
+                ContractResolver = new PrettyIIIFContractResolver(),
+            };
+        }
+
+        [Theory]
+        [InlineData(AccessTokenErrorConditions.InvalidRequest, "invalidRequest")]
+        [InlineData(AccessTokenErrorConditions.MissingCredentials, "missingCredentials")]
+        [InlineData(AccessTokenErrorConditions.InvalidCredentials, "invalidCredentials")]
+        [InlineData(AccessTokenErrorConditions.InvalidOrigin, "invalidOrigin")]
+        [InlineData(AccessTokenErrorConditions.Unavailable, "unavailable")]
+        public void AccessTokenError_ReturnsExpectedJson(AccessTokenErrorConditions error, string description)
+        {
+            // Arrange
+            var accessTokenError = new AccessTokenError(error, "test description");
+            
+            var expected = $"{{\"error\":\"{description}\",\"description\":\"test description\"}}";
+
+            var actual = JsonConvert.SerializeObject(accessTokenError, jsonSerializerSettings);
+
+            actual.Should().Be(expected);
+        }
+    }
+}

--- a/src/IIIF/IIIF.sln.DotSettings
+++ b/src/IIIF/IIIF.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=IIIF/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/IIIF/IIIF/Auth/V1/AccessTokenService/AccessTokenError.cs
+++ b/src/IIIF/IIIF/Auth/V1/AccessTokenService/AccessTokenError.cs
@@ -1,0 +1,77 @@
+﻿using System.ComponentModel;
+using IIIF.Serialisation;
+using Newtonsoft.Json;
+
+namespace IIIF.Auth.V1.AccessTokenService
+{
+    /// <summary>
+    /// Response from access token service in the result of an error
+    /// </summary>
+    /// <remarks>
+    /// See https://iiif.io/api/auth/1.0/#access-token-error-conditions
+    /// </remarks>
+    public class AccessTokenError
+    {
+        [JsonProperty(PropertyName = "error", Order = 1)]
+        [CamelCaseEnum]
+        public AccessTokenErrorConditions Error { get; set; }
+        
+        [JsonProperty(PropertyName = "description", Order = 2)]
+        public string Description { get; set; }
+
+        public AccessTokenError()
+        {
+        }
+
+        /// <summary>
+        /// Create new AccessTokenError using provided error condition and default description for condition
+        /// </summary>
+        public AccessTokenError(AccessTokenErrorConditions error) : this(error, error.GetDescription())
+        {
+        }
+
+        /// <summary>
+        /// Create new AccessTokenError using provided error condition and custom description of error
+        /// </summary>
+        public AccessTokenError(AccessTokenErrorConditions error, string description)
+        {
+            Error = error;
+            Description = description;
+        }
+    }
+
+
+    public enum AccessTokenErrorConditions
+    {
+        /// <summary>
+        /// The service could not process the information sent in the body of the request.
+        /// </summary>
+        [Description("The service could not process the information sent in the body of the request.")]
+        InvalidRequest,
+
+        /// <summary>
+        /// The request did not have the credentials required.
+        /// </summary>
+        [Description("The request did not have the credentials required.")]
+        MissingCredentials,
+
+        /// <summary>
+        /// The request had credentials that are not valid for the service.
+        /// </summary>
+        [Description("The request had credentials that are not valid for the service.")]
+        InvalidCredentials,
+
+        /// <summary>
+        /// The request came from a different origin than that specified in the access cookie service request,
+        /// or an origin that the server rejects for other reasons.
+        /// </summary>
+        [Description("The request came from a different origin than that specified in the access cookie service request, or an origin that the server rejects for other reasons.")]
+        InvalidOrigin,
+
+        /// <summary>
+        /// The request could not be fulfilled for reasons other than those listed above, such as scheduled maintenance.
+        /// </summary>
+        [Description("The request could not be fulfilled for reasons other than those listed above, such as scheduled maintenance.")] 
+        Unavailable
+    }
+}

--- a/src/IIIF/IIIF/Auth/V1/AccessTokenService/AccessTokenError.cs
+++ b/src/IIIF/IIIF/Auth/V1/AccessTokenService/AccessTokenError.cs
@@ -10,7 +10,7 @@ namespace IIIF.Auth.V1.AccessTokenService
     /// <remarks>
     /// See https://iiif.io/api/auth/1.0/#access-token-error-conditions
     /// </remarks>
-    public class AccessTokenError
+    public class AccessTokenError : JsonLdBase
     {
         [JsonProperty(PropertyName = "error", Order = 1)]
         [CamelCaseEnum]

--- a/src/IIIF/IIIF/Auth/V1/AccessTokenService/AccessTokenResponse.cs
+++ b/src/IIIF/IIIF/Auth/V1/AccessTokenService/AccessTokenResponse.cs
@@ -1,0 +1,22 @@
+﻿using Newtonsoft.Json;
+
+namespace IIIF.Auth.V1.AccessTokenService
+{
+    /// <summary>
+    /// Access Token response sent by access token service
+    /// </summary>
+    /// <remarks>
+    /// See https://iiif.io/api/auth/1.0/#the-json-access-token-response
+    /// </remarks>
+    public class AccessTokenResponse
+    {
+        [JsonProperty(PropertyName = "messageId", Order = 1)]
+        public string MessageId { get; set; }
+        
+        [JsonProperty(PropertyName = "accessToken", Order = 2)]
+        public string AccessToken { get; set; }
+        
+        [JsonProperty(PropertyName = "expiresIn", Order = 3)]
+        public int ExpiresIn { get; set; }
+    }
+}

--- a/src/IIIF/IIIF/Auth/V1/AccessTokenService/AccessTokenResponse.cs
+++ b/src/IIIF/IIIF/Auth/V1/AccessTokenService/AccessTokenResponse.cs
@@ -8,7 +8,7 @@ namespace IIIF.Auth.V1.AccessTokenService
     /// <remarks>
     /// See https://iiif.io/api/auth/1.0/#the-json-access-token-response
     /// </remarks>
-    public class AccessTokenResponse
+    public class AccessTokenResponse : JsonLdBase
     {
         [JsonProperty(PropertyName = "messageId", Order = 1)]
         public string MessageId { get; set; }

--- a/src/IIIF/IIIF/Serialisation/CamelCaseEnumAttribute.cs
+++ b/src/IIIF/IIIF/Serialisation/CamelCaseEnumAttribute.cs
@@ -4,7 +4,7 @@ namespace IIIF.Serialisation
 {
     /// <summary>
     /// Any enum property decorated with this attribute will have a serialised value of it's string representation
-    /// in camlelCase (e.g. InvalidRequest => invalidRequest)
+    /// in camelCase (e.g. InvalidRequest => invalidRequest)
     /// </summary>
     [AttributeUsage(AttributeTargets.Property)]
     public class CamelCaseEnumAttribute : Attribute

--- a/src/IIIF/IIIF/Serialisation/CamelCaseEnumAttribute.cs
+++ b/src/IIIF/IIIF/Serialisation/CamelCaseEnumAttribute.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace IIIF.Serialisation
+{
+    /// <summary>
+    /// Any enum property decorated with this attribute will have a serialised value of it's string representation
+    /// in camlelCase (e.g. InvalidRequest => invalidRequest)
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property)]
+    public class CamelCaseEnumAttribute : Attribute
+    {
+    }
+}

--- a/src/IIIF/IIIF/Serialisation/EnumCamelCaseValueConverter.cs
+++ b/src/IIIF/IIIF/Serialisation/EnumCamelCaseValueConverter.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using IIIF.Presentation.V2.Serialisation;
+using Newtonsoft.Json;
+
+namespace IIIF.Serialisation
+{
+    /// <summary>
+    /// Serialises enum as camelCase representation of enum value
+    /// </summary>
+    public class EnumCamelCaseValueConverter : WriteOnlyConverter
+    {
+        public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
+        {
+            if (value is not Enum enumValue)
+            {
+                throw new ArgumentException(
+                    $"EnumCamelCaseValueConverter expected enum but got {value.GetType().Name}", nameof(value));
+            }
+
+            writer.WriteValue(ConvertToCamelCase(enumValue.ToString()));
+        }
+        
+        private string ConvertToCamelCase(string name)
+        {
+            // Based on System.Text.Json.JsonNamingPolicy.CamelCase.ConvertName implementation
+            if (string.IsNullOrEmpty(name) || !char.IsUpper(name[0]))
+            {
+                return name;
+            }
+
+            char[] chars = name.ToCharArray();
+            FixCasing(chars);
+            return new string(chars);
+        }
+
+        private static void FixCasing(Span<char> chars)
+        {
+            for (int i = 0; i < chars.Length; i++)
+            {
+                if (i == 1 && !char.IsUpper(chars[i]))
+                {
+                    break;
+                }
+
+                bool hasNext = (i + 1 < chars.Length);
+
+                // Stop when next char is already lowercase.
+                if (i > 0 && hasNext && !char.IsUpper(chars[i + 1]))
+                {
+                    // If the next char is a space, lowercase current char before exiting.
+                    if (chars[i + 1] == ' ')
+                    {
+                        chars[i] = char.ToLowerInvariant(chars[i]);
+                    }
+
+                    break;
+                }
+
+                chars[i] = char.ToLowerInvariant(chars[i]);
+            }
+        }
+    }
+}

--- a/src/IIIF/IIIF/Serialisation/EnumX.cs
+++ b/src/IIIF/IIIF/Serialisation/EnumX.cs
@@ -1,0 +1,23 @@
+﻿using System.ComponentModel;
+using System.Linq;
+using System.Reflection;
+
+namespace IIIF.Serialisation
+{
+    internal static class EnumX
+    {
+        /// <summary>
+        /// Get Description value for enum. Will use <see cref="DescriptionAttribute"/> if found, or fall back to value.ToString().
+        /// </summary>
+        /// <param name="enumValue">Value to get description for.</param>
+        /// <typeparam name="T">Type of enum.</typeparam>
+        /// <returns>String description for enum value.</returns>
+        public static string GetDescription<T>(this T enumValue)
+            where T : System.Enum
+        {
+            var memberInfo = typeof(T).GetMember(enumValue.ToString()).Single();
+            var desc = memberInfo.GetCustomAttribute<DescriptionAttribute>();
+            return desc == null ? enumValue.ToString() : desc.Description;
+        }
+    }
+}

--- a/src/IIIF/IIIF/Serialisation/PrettyIIIFContractResolver.cs
+++ b/src/IIIF/IIIF/Serialisation/PrettyIIIFContractResolver.cs
@@ -13,6 +13,8 @@ namespace IIIF.Serialisation
     {
         // adapted from https://stackoverflow.com/a/34903827
         private static readonly ObjectIfSingleConverter ObjectIfSingleConverter = new();
+
+        private static readonly EnumCamelCaseValueConverter EnumCamelCaseValueConverter = new();
         
         protected override JsonProperty CreateProperty(
             MemberInfo member,
@@ -33,6 +35,11 @@ namespace IIIF.Serialisation
                         ?.GetValue(instance);
                     return o != null && (int) o != 0;
                 };
+            }
+            
+            if (member.GetCustomAttribute<CamelCaseEnumAttribute>() != null)
+            {
+                property.Converter = EnumCamelCaseValueConverter;
             }
             
             // Don't serialise empty lists, unless they have the [RequiredOutput] attribute


### PR DESCRIPTION
Added 2 new auth models - `AccessTokenResponse` and `AccessTokenError` with serialisation helpers for the latter.