### PR TITLE
Removed the conditionals regarding a targeted Canvas.

### DIFF
--- a/src/IIIF/IIIF/Serialisation/TargetConverter.cs
+++ b/src/IIIF/IIIF/Serialisation/TargetConverter.cs
@@ -40,14 +40,10 @@ namespace IIIF.Serialisation
         {
             if (value is Canvas canvas)
             {
-                if (canvas.Width == null && canvas.Duration == null && (canvas.Items == null || !canvas.Items.Any()))
-                {
-                    writer.WriteValue(canvas.Id);
-                    return;
-                }
+                writer.WriteValue(canvas.Id);
+                return;
             }
-            // Default, pass through behaviour:
-            JObject.FromObject(value, serializer).WriteTo(writer);
+            // TODO: add other types
         }
     }
 }


### PR DESCRIPTION
It was necessary for outputting the Annotation.Target property which is a canvas which in our case is an ancestor that holds a lot of information.

I'm not so sure about these changes, so regard them more as a question than a regular PR.

My use case was that I needed to output a target canvas reference and not the complete actual canvas. So that is what I changed the code to. I guess I'm probably breaking something else with this, so feel free to toss this in the bin :-)