### PR TITLE
Add Canvas.SerialiseTargetAsId to control AnnotationTarget serialisation

### DIFF
--- a/src/IIIF/IIIF.Tests/Presentation/V3/CanvasTests.cs
+++ b/src/IIIF/IIIF.Tests/Presentation/V3/CanvasTests.cs
@@ -1,0 +1,161 @@
+﻿using System.Collections.Generic;
+using FluentAssertions;
+using IIIF.Presentation.V3;
+using IIIF.Presentation.V3.Annotation;
+using IIIF.Presentation.V3.Strings;
+using IIIF.Serialisation;
+using Xunit;
+
+namespace IIIF.Tests.Presentation.V3
+{
+    public class CanvasTests
+    {
+        [Fact]
+        public void SerialiseTargetAsId_True_RendersIdAsTarget()
+        {
+            var targetIsIdOnlyCanvas = new Canvas
+            {
+                Id = "https://test.example.com/canvas/target-id-only",
+                Width = 1000,
+                Height = 1001,
+                SerialiseTargetAsId = true
+            };
+
+            var referencingCanvas = new Canvas
+            {
+                Id = "https://test.example.com/canvas/referencing",
+                Items = new List<AnnotationPage>
+                {
+                    new()
+                    {
+                        Id = "https://test.example.com/canvas/referencing/page",
+                        Items = new List<IAnnotation>
+                        {
+                            new PaintingAnnotation { Target = targetIsIdOnlyCanvas, }
+                        }
+                    }
+                }
+            };
+            
+            var manifest = new Manifest
+            {
+                Context = "http://iiif.io/api/presentation/3/context.json",
+                Id = "https://test.example.com/manifest",
+                Label = new LanguageMap("en", "Test string"),
+                Items = new List<Canvas> { targetIsIdOnlyCanvas, referencingCanvas }
+            };
+
+            var serialisedManifest = manifest.AsJson();
+
+            const string expected = @"{
+  ""@context"": ""http://iiif.io/api/presentation/3/context.json"",
+  ""id"": ""https://test.example.com/manifest"",
+  ""type"": ""Manifest"",
+  ""label"": {""en"":[""Test string""]},
+  ""items"": [
+    {
+      ""id"": ""https://test.example.com/canvas/target-id-only"",
+      ""type"": ""Canvas"",
+      ""width"": 1000,
+      ""height"": 1001
+    },
+    {
+      ""id"": ""https://test.example.com/canvas/referencing"",
+      ""type"": ""Canvas"",
+      ""items"": [
+        {
+          ""id"": ""https://test.example.com/canvas/referencing/page"",
+          ""type"": ""AnnotationPage"",
+          ""items"": [
+            {
+              ""type"": ""Annotation"",
+              ""motivation"": ""painting"",
+              ""target"": ""https://test.example.com/canvas/target-id-only""
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}";
+            
+            serialisedManifest.Should().BeEquivalentTo(expected);
+        }
+        
+        [Fact]
+        public void SerialiseTargetAsId_False_RendersFullCanvasAsTarget()
+        {
+            var targetIsIdOnlyCanvas = new Canvas
+            {
+                Id = "https://test.example.com/canvas/full",
+                Width = 1000,
+                Height = 1001,
+            };
+
+            var referencingCanvas = new Canvas
+            {
+                Id = "https://test.example.com/canvas/referencing",
+                Items = new List<AnnotationPage>
+                {
+                    new()
+                    {
+                        Id = "https://test.example.com/canvas/referencing/page",
+                        Items = new List<IAnnotation>
+                        {
+                            new PaintingAnnotation { Target = targetIsIdOnlyCanvas, }
+                        }
+                    }
+                }
+            };
+            
+            var manifest = new Manifest
+            {
+                Context = "http://iiif.io/api/presentation/3/context.json",
+                Id = "https://test.example.com/manifest",
+                Label = new LanguageMap("en", "Test string"),
+                Items = new List<Canvas> { targetIsIdOnlyCanvas, referencingCanvas }
+            };
+
+            var serialisedManifest = manifest.AsJson();
+
+            const string expected = @"{
+  ""@context"": ""http://iiif.io/api/presentation/3/context.json"",
+  ""id"": ""https://test.example.com/manifest"",
+  ""type"": ""Manifest"",
+  ""label"": {""en"":[""Test string""]},
+  ""items"": [
+    {
+      ""id"": ""https://test.example.com/canvas/full"",
+      ""type"": ""Canvas"",
+      ""width"": 1000,
+      ""height"": 1001
+    },
+    {
+      ""id"": ""https://test.example.com/canvas/referencing"",
+      ""type"": ""Canvas"",
+      ""items"": [
+        {
+          ""id"": ""https://test.example.com/canvas/referencing/page"",
+          ""type"": ""AnnotationPage"",
+          ""items"": [
+            {
+              ""type"": ""Annotation"",
+              ""motivation"": ""painting"",
+              ""target"": {
+                ""id"": ""https://test.example.com/canvas/full"",
+                ""type"": ""Canvas"",
+                ""width"": 1000,
+                ""height"": 1001
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}";
+            
+            serialisedManifest.Should().BeEquivalentTo(expected);
+        }
+    }
+}

--- a/src/IIIF/IIIF.Tests/Presentation/V3/CanvasTests.cs
+++ b/src/IIIF/IIIF.Tests/Presentation/V3/CanvasTests.cs
@@ -45,7 +45,7 @@ namespace IIIF.Tests.Presentation.V3
                 Items = new List<Canvas> { targetIsIdOnlyCanvas, referencingCanvas }
             };
 
-            var serialisedManifest = manifest.AsJson();
+            var serialisedManifest = manifest.AsJson().Replace("\r\n", "\n");
 
             const string expected = @"{
   ""@context"": ""http://iiif.io/api/presentation/3/context.json"",
@@ -116,7 +116,7 @@ namespace IIIF.Tests.Presentation.V3
                 Items = new List<Canvas> { targetIsIdOnlyCanvas, referencingCanvas }
             };
 
-            var serialisedManifest = manifest.AsJson();
+            var serialisedManifest = manifest.AsJson().Replace("\r\n", "\n");
 
             const string expected = @"{
   ""@context"": ""http://iiif.io/api/presentation/3/context.json"",

--- a/src/IIIF/IIIF.Tests/Serialisation/TargetConverterTests.cs
+++ b/src/IIIF/IIIF.Tests/Serialisation/TargetConverterTests.cs
@@ -1,5 +1,7 @@
-﻿using FluentAssertions;
+﻿using System.Collections.Generic;
+using FluentAssertions;
 using IIIF.Presentation.V3;
+using IIIF.Presentation.V3.Annotation;
 using IIIF.Serialisation;
 using Newtonsoft.Json;
 using Xunit;
@@ -28,6 +30,34 @@ namespace IIIF.Tests.Serialisation
             result.Should().Be($"\"{testId}\"");
         }
         
+        [Fact]
+        public void ConvertCanvas_EmptyItems_OutputsIdOnly()
+        {
+            // Arrange
+            const string testId = "https://test.example.com/canvas";
+            var canvas = new Canvas { Id = testId, Items = new List<AnnotationPage>(0) };
+
+            // Act
+            var result = JsonConvert.SerializeObject(canvas, Formatting.None, sut);
+            
+            // Assert
+            result.Should().Be($"\"{testId}\"");
+        }
+        
+        [Fact]
+        public void ConvertCanvas_SerialiseTargetAsIdTrue_OnlyReturnsId()
+        {
+            // Arrange
+            const string testId = "https://test.example.com/canvas";
+            var canvas = new Canvas { Id = testId, Width = 300, Height = 200, SerialiseTargetAsId = true};
+
+            // Act
+            var result = JsonConvert.SerializeObject(canvas, Formatting.None, sut);
+            
+            // Assert
+            result.Should().Be($"\"{testId}\"");
+        }
+
         [Fact]
         public void CanDeserialise_SerialisedIdOnlyCanvas()
         {

--- a/src/IIIF/IIIF/Presentation/V3/Canvas.cs
+++ b/src/IIIF/IIIF/Presentation/V3/Canvas.cs
@@ -33,5 +33,12 @@ namespace IIIF.Presentation.V3
         
         [JsonProperty(Order = 300)]
         public List<AnnotationPage>? Items { get; set; }
+
+        /// <summary>
+        /// Used to control serialisation logic for Canvas items that are <see cref="Annotation"/> Targets.
+        /// If true then Target is serialised as simple Id string only.
+        /// </summary>
+        [JsonIgnore]
+        public bool SerialiseTargetAsId { get; set; }
     }
 }

--- a/src/IIIF/IIIF/Serialisation/TargetConverter.cs
+++ b/src/IIIF/IIIF/Serialisation/TargetConverter.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using IIIF.Presentation.V3;
+using IIIF.Utils;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Range = IIIF.Presentation.V3.Range;
@@ -13,7 +14,8 @@ namespace IIIF.Serialisation
     /// </summary>
     public class TargetConverter : JsonConverter<IStructuralLocation>
     {
-        public override IStructuralLocation? ReadJson(JsonReader reader, Type objectType, IStructuralLocation? existingValue,
+        public override IStructuralLocation? ReadJson(JsonReader reader, Type objectType,
+            IStructuralLocation? existingValue,
             bool hasExistingValue, JsonSerializer serializer)
         {
             if (reader.TokenType == JsonToken.String)
@@ -35,19 +37,20 @@ namespace IIIF.Serialisation
 
             return null;
         }
-        
+
         public override void WriteJson(JsonWriter writer, IStructuralLocation? value, JsonSerializer serializer)
         {
-            if (value is Canvas canvas)
+            if (value is Canvas canvas && (canvas.SerialiseTargetAsId || IsSimpleCanvas(canvas)))
             {
-                if (canvas.Width == null && canvas.Duration == null && (canvas.Items == null || !canvas.Items.Any()))
-                {
-                    writer.WriteValue(canvas.Id);
-                    return;
-                }
+                writer.WriteValue(canvas.Id);
+                return;
             }
+
             // Default, pass through behaviour:
             JObject.FromObject(value, serializer).WriteTo(writer);
         }
+
+        private static bool IsSimpleCanvas(Canvas canvas)
+            => canvas.Width == null && canvas.Duration == null && canvas.Items.IsNullOrEmpty();
     }
 }

--- a/src/IIIF/IIIF/Utils/CollectionX.cs
+++ b/src/IIIF/IIIF/Utils/CollectionX.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+
+namespace IIIF.Utils
+{
+    internal static class CollectionX
+    {
+        public static bool IsNullOrEmpty<T>(this List<T> collection)
+            => collection == null || collection.Count == 0;
+    }
+}


### PR DESCRIPTION
New property `SerialiseTargetAsId` is only used to control serialisation of Annotation.Target properties.

If `true` then `"id"` string rendered only. If `false` previously behaviour stands.