### PR TITLE
Add size helpers, more calculations and processing via SizeParameter

### DIFF
--- a/src/IIIF/IIIF.Tests/ImageApi/ImageRequestXTests.cs
+++ b/src/IIIF/IIIF.Tests/ImageApi/ImageRequestXTests.cs
@@ -1,0 +1,225 @@
+﻿using FluentAssertions;
+using IIIF.ImageApi;
+using Xunit;
+
+namespace IIIF.Tests.ImageApi
+{
+    public class ImageRequestXTests
+    {
+        [Fact]
+        public void Parse_CorrectMax()
+        {
+            // Arrange
+            var sizeParameter = new SizeParameter
+            {
+                Max = true
+            };
+            var originalSize = new Size(400, 400);
+            var expected = new Size(400, 400);
+            
+            // Act
+            var result = sizeParameter.GetResultingSize(originalSize);
+            
+            // Assert
+            result.Should().BeEquivalentTo(expected);
+        }
+        
+        [Fact]
+        public void Parse_CorrectMaxScaled()
+        {
+            // Arrange
+            var sizeParameter = new SizeParameter
+            {
+                Max = true, Upscaled = true
+            };
+            var originalSize = new Size(400, 400);
+            var expected = new Size(400, 400);
+            
+            // Act
+            var result = sizeParameter.GetResultingSize(originalSize);
+            
+            // Assert
+            result.Should().BeEquivalentTo(expected);
+        }
+        
+        [Fact]
+        public void Parse_CorrectWidthOnly()
+        {
+            // Arrange
+            var sizeParameter = new SizeParameter
+            {
+                Width = 100
+            };
+            var originalSize = new Size(400, 800);
+            var expected = new Size(100, 200);
+            
+            // Act
+            var result = sizeParameter.GetResultingSize(originalSize);
+            
+            // Assert
+            result.Should().BeEquivalentTo(expected);
+        }
+        
+        [Fact]
+        public void Parse_CorrectWidthOnlyScaled()
+        {
+            // Arrange
+            var sizeParameter = new SizeParameter
+            {
+                Width = 100, Upscaled = true
+            };
+            var originalSize = new Size(400, 800);
+            var expected = new Size(100, 200);
+            
+            // Act
+            var result = sizeParameter.GetResultingSize(originalSize);
+            
+            // Assert
+            result.Should().BeEquivalentTo(expected);
+        }
+        
+        [Fact]
+        public void Parse_CorrectHeightOnly()
+        {
+            // Arrange
+            var sizeParameter = new SizeParameter
+            {
+                Height = 40
+            };
+            var originalSize = new Size(400, 800);
+            var expected = new Size(20, 40);
+            
+            // Act
+            var result = sizeParameter.GetResultingSize(originalSize);
+            
+            // Assert
+            result.Should().BeEquivalentTo(expected);
+        }
+        
+        [Fact]
+        public void Parse_CorrectHeightOnlyScaled()
+        {
+            // Arrange
+            var sizeParameter = new SizeParameter
+            {
+                Height = 40, Upscaled = true
+            };
+            var originalSize = new Size(400, 800);
+            var expected = new Size(20, 40);
+            
+            // Act
+            var result = sizeParameter.GetResultingSize(originalSize);
+            
+            // Assert
+            result.Should().BeEquivalentTo(expected);
+        }
+        
+        [Fact]
+        public void Parse_CorrectWidthHeight()
+        {
+            // Arrange
+            var sizeParameter = new SizeParameter
+            {
+                Width = 90, Height = 40
+            };
+            var originalSize = new Size(400, 800);
+            var expected = new Size(90, 40);
+            
+            // Act
+            var result = sizeParameter.GetResultingSize(originalSize);
+            
+            // Assert
+            result.Should().BeEquivalentTo(expected);
+        }
+        
+        [Fact]
+        public void Parse_CorrectWidthHeightScaled()
+        {
+            // Arrange
+            var sizeParameter = new SizeParameter
+            {
+                Width = 90, Height = 40, Upscaled = true
+            };
+            var originalSize = new Size(400, 800);
+            var expected = new Size(90, 40);
+            
+            // Act
+            var result = sizeParameter.GetResultingSize(originalSize);
+            
+            // Assert
+            result.Should().BeEquivalentTo(expected);
+        }
+        
+        [Fact]
+        public void Parse_CorrectWidthHeightConfined()
+        {
+            // Arrange
+            var sizeParameter = new SizeParameter
+            {
+                Width = 90, Height = 40, Confined = true
+            };
+            var originalSize = new Size(400, 800);
+            var expected = new Size(20, 40);
+            
+            // Act
+            var result = sizeParameter.GetResultingSize(originalSize);
+            
+            // Assert
+            result.Should().BeEquivalentTo(expected);
+        }
+        
+        [Fact]
+        public void Parse_CorrectWidthHeightScaledConfined()
+        {
+            // Arrange
+            var sizeParameter = new SizeParameter
+            {
+                Width = 90, Height = 40, Confined = true, Upscaled = true
+            };
+            var originalSize = new Size(400, 800);
+            var expected = new Size(20, 40);
+            
+            // Act
+            var result = sizeParameter.GetResultingSize(originalSize);
+            
+            // Assert
+            result.Should().BeEquivalentTo(expected);
+        }
+        
+        [Fact]
+        public void Parse_CorrectPercentage()
+        {
+            // Arrange
+            var sizeParameter = new SizeParameter
+            {
+                PercentScale = 30f
+            };
+            var originalSize = new Size(400, 800);
+            var expected = new Size(120, 240);
+            
+            // Act
+            var result = sizeParameter.GetResultingSize(originalSize);
+            
+            // Assert
+            result.Should().BeEquivalentTo(expected);
+        }
+        
+        [Fact]
+        public void Parse_CorrectPercentageScaled()
+        {
+            // Arrange
+            var sizeParameter = new SizeParameter
+            {
+                PercentScale = 30f, Upscaled = true
+            };
+            var originalSize = new Size(400, 800);
+            var expected = new Size(120, 240);
+            
+            // Act
+            var result = sizeParameter.GetResultingSize(originalSize);
+            
+            // Assert
+            result.Should().BeEquivalentTo(expected);
+        }
+    }
+}

--- a/src/IIIF/IIIF.Tests/ImageApi/SizeParameterTests.cs
+++ b/src/IIIF/IIIF.Tests/ImageApi/SizeParameterTests.cs
@@ -1,0 +1,225 @@
+﻿using FluentAssertions;
+using IIIF.ImageApi;
+using Xunit;
+
+namespace IIIF.Tests.ImageApi
+{
+    public class SizeParameterTests
+    {
+        [Fact]
+        public void Parse_CorrectMax()
+        {
+            // Arrange
+            const string size = "max";
+            var expected = new SizeParameter
+            {
+                Max = true
+            };
+            
+            // Act
+            var sizeParameter = SizeParameter.Parse(size);
+            
+            // Assert
+            sizeParameter.Should().BeEquivalentTo(expected);
+            sizeParameter.ToString().Should().Be(size);
+        }
+        
+        [Fact]
+        public void Parse_CorrectMaxScaled()
+        {
+            // Arrange
+            const string size = "^max";
+            var expected = new SizeParameter
+            {
+                Max = true, Upscaled = true
+            };
+            
+            // Act
+            var sizeParameter = SizeParameter.Parse(size);
+            
+            // Assert
+            sizeParameter.Should().BeEquivalentTo(expected);
+            sizeParameter.ToString().Should().Be(size);
+        }
+        
+        [Fact]
+        public void Parse_CorrectWidthOnly()
+        {
+            // Arrange
+            const string size = "100,";
+            var expected = new SizeParameter
+            {
+                Width = 100
+            };
+            
+            // Act
+            var sizeParameter = SizeParameter.Parse(size);
+            
+            // Assert
+            sizeParameter.Should().BeEquivalentTo(expected);
+            sizeParameter.ToString().Should().Be(size);
+        }
+        
+        [Fact]
+        public void Parse_CorrectWidthOnlyScaled()
+        {
+            // Arrange
+            const string size = "^100,";
+            var expected = new SizeParameter
+            {
+                Width = 100, Upscaled = true
+            };
+            
+            // Act
+            var sizeParameter = SizeParameter.Parse(size);
+            
+            // Assert
+            sizeParameter.Should().BeEquivalentTo(expected);
+            sizeParameter.ToString().Should().Be(size);
+        }
+        
+        [Fact]
+        public void Parse_CorrectHeightOnly()
+        {
+            // Arrange
+            const string size = ",40";
+            var expected = new SizeParameter
+            {
+                Height = 40
+            };
+            
+            // Act
+            var sizeParameter = SizeParameter.Parse(size);
+            
+            // Assert
+            sizeParameter.Should().BeEquivalentTo(expected);
+            sizeParameter.ToString().Should().Be(size);
+        }
+        
+        [Fact]
+        public void Parse_CorrectHeightOnlyScaled()
+        {
+            // Arrange
+            const string size = "^,40";
+            var expected = new SizeParameter
+            {
+                Height = 40, Upscaled = true
+            };
+            
+            // Act
+            var sizeParameter = SizeParameter.Parse(size);
+            
+            // Assert
+            sizeParameter.Should().BeEquivalentTo(expected);
+            sizeParameter.ToString().Should().Be(size);
+        }
+        
+        [Fact]
+        public void Parse_CorrectWidthHeight()
+        {
+            // Arrange
+            const string size = "90,40";
+            var expected = new SizeParameter
+            {
+                Width = 90, Height = 40
+            };
+            
+            // Act
+            var sizeParameter = SizeParameter.Parse(size);
+            
+            // Assert
+            sizeParameter.Should().BeEquivalentTo(expected);
+            sizeParameter.ToString().Should().Be(size);
+        }
+        
+        [Fact]
+        public void Parse_CorrectWidthHeightScaled()
+        {
+            // Arrange
+            const string size = "^90,40";
+            var expected = new SizeParameter
+            {
+                Width = 90, Height = 40, Upscaled = true
+            };
+            
+            // Act
+            var sizeParameter = SizeParameter.Parse(size);
+            
+            // Assert
+            sizeParameter.Should().BeEquivalentTo(expected);
+            sizeParameter.ToString().Should().Be(size);
+        }
+        
+        [Fact]
+        public void Parse_CorrectWidthHeightConfined()
+        {
+            // Arrange
+            const string size = "!90,40";
+            var expected = new SizeParameter
+            {
+                Width = 90, Height = 40, Confined = true
+            };
+            
+            // Act
+            var sizeParameter = SizeParameter.Parse(size);
+            
+            // Assert
+            sizeParameter.Should().BeEquivalentTo(expected);
+            sizeParameter.ToString().Should().Be(size);
+        }
+        
+        [Fact]
+        public void Parse_CorrectWidthHeightScaledConfined()
+        {
+            // Arrange
+            const string size = "^!90,40";
+            var expected = new SizeParameter
+            {
+                Width = 90, Height = 40, Confined = true, Upscaled = true
+            };
+            
+            // Act
+            var sizeParameter = SizeParameter.Parse(size);
+            
+            // Assert
+            sizeParameter.Should().BeEquivalentTo(expected);
+            sizeParameter.ToString().Should().Be(size);
+        }
+        
+        [Fact]
+        public void Parse_CorrectPercentage()
+        {
+            // Arrange
+            const string size = "pct:30";
+            var expected = new SizeParameter
+            {
+                PercentScale = 30f
+            };
+            
+            // Act
+            var sizeParameter = SizeParameter.Parse(size);
+            
+            // Assert
+            sizeParameter.Should().BeEquivalentTo(expected);
+            sizeParameter.ToString().Should().Be(size);
+        }
+        
+        [Fact]
+        public void Parse_CorrectPercentageScaled()
+        {
+            // Arrange
+            const string size = "^pct:30";
+            var expected = new SizeParameter
+            {
+                PercentScale = 30f, Upscaled = true
+            };
+            
+            // Act
+            var sizeParameter = SizeParameter.Parse(size);
+            
+            // Assert
+            sizeParameter.Should().BeEquivalentTo(expected);
+            sizeParameter.ToString().Should().Be(size);
+        }
+    }
+}

--- a/src/IIIF/IIIF.Tests/ImageApi/SizeTests.cs
+++ b/src/IIIF/IIIF.Tests/ImageApi/SizeTests.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using FluentAssertions;
 using Xunit;
 
-namespace IIIF.Tests
+namespace IIIF.Tests.ImageApi
 {
     public class SizeTests
     {
@@ -204,6 +204,34 @@ namespace IIIF.Tests
             // Assert
             newSize.Height.Should().Be(height);
             newSize.Width.Should().Be(expectedWidth);
+        }
+
+        [Fact]
+        public void Resize_Percentage_CorrectSmaller()
+        {
+            // Arrange
+            var size = new Size(100, 200);
+            
+            // Act
+            var newSize = Size.ResizePercent(size, 30f);
+            
+            // Assert
+            newSize.Width.Should().Be(30);
+            newSize.Height.Should().Be(60);
+        }
+        
+        [Fact]
+        public void Resize_Percentage_CorrectLarger()
+        {
+            // Arrange
+            var size = new Size(100, 200);
+            
+            // Act
+            var newSize = Size.ResizePercent(size, 130f);
+            
+            // Assert
+            newSize.Width.Should().Be(130);
+            newSize.Height.Should().Be(260);
         }
 
         [Theory]

--- a/src/IIIF/IIIF/IIIF.csproj
+++ b/src/IIIF/IIIF/IIIF.csproj
@@ -10,6 +10,7 @@
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <ProjectUrl>https://github.com/digirati-co-uk/iiif-net</ProjectUrl>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>
+        <Nullable>enable</Nullable>
     </PropertyGroup>  
 
     <ItemGroup>

--- a/src/IIIF/IIIF/ImageApi/ImageRequest.cs
+++ b/src/IIIF/IIIF/ImageApi/ImageRequest.cs
@@ -29,26 +29,26 @@ namespace IIIF.ImageApi
         {
             if (path[0] == '/')
             {
-                path = path.Substring(1);
+                path = path[1..];
             }
 
             if (prefix.Length > 0)
             {
                 if (prefix[0] == '/')
                 {
-                    prefix = prefix.Substring(1);
+                    prefix = prefix[1..];
                 }
-                if (prefix != path.Substring(0, prefix.Length))
+                if (prefix != path[..prefix.Length])
                 {
                     throw new ArgumentException("Path does not start with prefix", nameof(prefix));
                 }
-                path = path.Substring(prefix.Length);
+                path = path[prefix.Length..];
             }
 
             var request = new ImageRequest { Prefix = prefix };
             var parts = path.Split('/');
             request.Identifier = parts[0];
-            if (parts.Length == 1 || parts[1] == String.Empty)
+            if (parts.Length == 1 || parts[1] == string.Empty)
             {
                 // likely the server will want to redirect this
                 request.IsBase = true;

--- a/src/IIIF/IIIF/ImageApi/ImageRequestX.cs
+++ b/src/IIIF/IIIF/ImageApi/ImageRequestX.cs
@@ -1,0 +1,39 @@
+﻿namespace IIIF.ImageApi
+{
+    /// <summary>
+    /// Extension methods for dealing with ImageRequests
+    /// </summary>
+    public static class ImageRequestX
+    {
+        /// <summary>
+        /// Resize the original object in accordance with size parameters.
+        /// This method supports upsizing and always allows upscaling.
+        /// </summary>
+        /// <param name="sizeParameter">Current <see cref="SizeParameter"/> object</param>
+        /// <param name="requestSize">
+        /// <see cref="Size"/> of requested resource - this can be original image for /full/ requests or size of tile
+        /// for tile requests etc
+        /// </param>
+        /// <returns></returns>
+        public static Size GetResultingSize(this SizeParameter sizeParameter, Size requestSize)
+        {
+            if (sizeParameter.Max)
+            {
+                return requestSize;
+            }
+
+            if (sizeParameter.PercentScale.HasValue)
+            {
+                return Size.ResizePercent(requestSize, sizeParameter.PercentScale.Value);
+            }
+
+            if (sizeParameter.Width.HasValue && sizeParameter.Height.HasValue && sizeParameter.Confined)
+            {
+                var targetSize = new Size(sizeParameter.Width.Value, sizeParameter.Height.Value);
+                return Size.Confine(targetSize, requestSize);
+            }
+            
+            return Size.Resize(requestSize, sizeParameter.Width, sizeParameter.Height);
+        }
+    }
+}

--- a/src/IIIF/IIIF/ImageApi/RotationParameter.cs
+++ b/src/IIIF/IIIF/ImageApi/RotationParameter.cs
@@ -15,7 +15,7 @@
             if (pathPart[0] == '!')
             {
                 rotation.Mirror = true;
-                pathPart = pathPart.Substring(1);
+                pathPart = pathPart[1..];
             }
             rotation.Angle = float.Parse(pathPart);
             return rotation;

--- a/src/IIIF/IIIF/ImageApi/SizeParameter.cs
+++ b/src/IIIF/IIIF/ImageApi/SizeParameter.cs
@@ -19,7 +19,7 @@ namespace IIIF.ImageApi
         
         public bool Confined { get; set; }
         
-        public float PercentScale { get; set; }
+        public float? PercentScale { get; set; }
 
         public override string ToString()
         {
@@ -58,13 +58,14 @@ namespace IIIF.ImageApi
         public static SizeParameter Parse(string pathPart)
         {
             var size = new SizeParameter();
+            
             if (pathPart[0] == '^')
             {
                 size.Upscaled = true;
-                pathPart = pathPart.Substring(1);
+                pathPart = pathPart[1..];
             }
 
-            if (pathPart == "max" || pathPart == "full")
+            if (pathPart is "max" or "full")
             {
                 size.Max = true;
                 return size;
@@ -73,21 +74,21 @@ namespace IIIF.ImageApi
             if (pathPart[0] == '!')
             {
                 size.Confined = true;
-                pathPart = pathPart.Substring(1);
+                pathPart = pathPart[1..];
             }
 
             if (pathPart[0] == 'p')
             {
-                size.PercentScale = float.Parse(pathPart.Substring(4));
+                size.PercentScale = float.Parse(pathPart[4..]);
                 return size;
             }
 
             string[] wh = pathPart.Split(',');
-            if (wh[0] != String.Empty)
+            if (wh[0] != string.Empty)
             {
                 size.Width = int.Parse(wh[0]);
             }
-            if (wh[1] != String.Empty)
+            if (wh[1] != string.Empty)
             {
                 size.Height = int.Parse(wh[1]);
             }

--- a/src/IIIF/IIIF/Size.cs
+++ b/src/IIIF/IIIF/Size.cs
@@ -110,7 +110,7 @@ namespace IIIF
         }
 
         /// <summary>
-        /// Resize specified image using Width or Height.
+        /// Resize specified Size to new Width and/or Height.
         /// Maintains aspect ratio unless both are specified.
         /// </summary>
         public static Size Resize(Size size, int? targetWidth = null, int? targetHeight = null)
@@ -129,6 +129,16 @@ namespace IIIF
             return new Size(
                 targetWidth ?? size.Width * targetHeight!.Value / size.Height,
                 targetHeight ?? size.Height * targetWidth!.Value / size.Width);
+        }
+
+        /// <summary>
+        /// Resize specified Size growing/shrinking by specified % value
+        /// </summary>
+        public static Size ResizePercent(Size size, float percentage)
+        {
+            var width = Convert.ToInt32(size.Width * (percentage / 100));
+            var height = Convert.ToInt32(size.Height * (percentage / 100));
+            return new Size(width, height);
         }
 
         /// <summary>


### PR DESCRIPTION
Add `Size.ResizePercentage()` helper and `ImageRequestX` class, currently only containing method for applying `SizeParameter` settings to an existing `Size`. This method _doesn't_ check whether upscaling is requested - it will always upsize.