### PR TITLE
duration should come right after width and height

### DIFF
--- a/src/IIIF/IIIF/Presentation/V3/Canvas.cs
+++ b/src/IIIF/IIIF/Presentation/V3/Canvas.cs
@@ -28,7 +28,7 @@ namespace IIIF.Presentation.V3
         /// <summary>
         /// The Duration of the Canvas, in seconds.
         /// </summary>
-        [JsonProperty(Order = 103)]
+        [JsonProperty(Order = 13)]
         public double? Duration { get; set; }
         
         [JsonProperty(Order = 300)]


### PR DESCRIPTION
This is a minor annoyance:

![image](https://user-images.githubusercontent.com/1443575/195328661-6e1f1ab4-d181-49e3-86c5-d7ab0229bc58.png)

I wonder if the original version was actually a typo?
