### PR TITLE
Auth v2 provisional classes

### DIFF
--- a/src/IIIF/IIIF.Tests/Auth/V2/ContentResourceWithAuthTest.cs
+++ b/src/IIIF/IIIF.Tests/Auth/V2/ContentResourceWithAuthTest.cs
@@ -1,0 +1,30 @@
+using FluentAssertions;
+using IIIF.Presentation.V3.Content;
+using IIIF.Serialisation;
+using Xunit;
+
+namespace IIIF.Tests.Auth.V2
+{
+    public class ContentResourceWithAuthTest
+    {
+        [Fact]
+        public void ContentResource_Can_Have_Auth_Services()
+        {
+            // Arrange
+            var res = new ExternalResource("Text")
+            {
+                Id = "https://example.com/documents/my.pdf",
+                Service = ReusableParts.Auth2Services
+            };
+            
+            // Act
+            var json = res.AsJson().Replace("\r\n", "\n");
+            const string expected = @"{
+  ""id"": ""https://example.com/documents/my.pdf"",
+  ""type"": ""Text""," + ReusableParts.ExpectedService + @"
+}";
+            // Assert
+            json.Should().BeEquivalentTo(expected);
+        }
+    }
+}

--- a/src/IIIF/IIIF.Tests/Auth/V2/ImageServiceWithAuthTest.cs
+++ b/src/IIIF/IIIF.Tests/Auth/V2/ImageServiceWithAuthTest.cs
@@ -1,18 +1,115 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using IIIF.Auth.V2;
 using IIIF.ImageApi.V2;
+using IIIF.ImageApi.V3;
+using IIIF.Presentation.V3.Strings;
+using IIIF.Serialisation;
 using Xunit;
 
 namespace IIIF.Tests.Auth.V2
 {
     public class ImageServiceWithAuthTest
     {
-        [Fact]
-        public void ImageService_Can_Have_Auth_Services()
+        const string ExpectedService = @"
+  ""service"": [
+    {
+      ""id"": ""https://example.com/image/service/probe"",
+      ""type"": ""AuthProbeService2""
+    },
+    {
+      ""id"": ""https://example.com/login"",
+      ""type"": ""AuthAccessService2"",
+      ""profile"": ""interactive"",
+      ""service"": [
         {
-            var imgService = new ImageService2
+          ""id"": ""https://example.com/token"",
+          ""type"": ""AuthTokenService2""
+        },
+        {
+          ""id"": ""https://example.com/logout"",
+          ""type"": ""AuthLogoutService2"",
+          ""label"": {""en"":[""Logout from Example Institution""]}
+        }
+      ],
+      ""confirmLabel"": {""en"":[""ConfirmLabel property""]},
+      ""header"": {""en"":[""Header property""]},
+      ""description"": {""en"":[""Description property""]},
+      ""failureHeader"": {""en"":[""FailureHeader property""]},
+      ""failureDescription"": {""en"":[""FailureDescription property""]}
+    }
+  ]";
+
+        private readonly List<IService> auth2Services = new List<IService>
+        {
+            new AuthProbeService2
             {
+                Id = "https://example.com/image/service/probe"
+            },
+            new AuthAccessService2
+            {
+                Id = "https://example.com/login",
+                Profile = AuthAccessService2.InteractiveProfile,
+                ConfirmLabel = new LanguageMap("en", "ConfirmLabel property"),
+                Header = new LanguageMap("en", "Header property"),
+                Description = new LanguageMap("en", "Description property"),
+                FailureHeader = new LanguageMap("en", "FailureHeader property"),
+                FailureDescription = new LanguageMap("en", "FailureDescription property"),
+                Service = new List<IService>
+                {
+                    new AuthTokenService2
+                    {
+                        Id = "https://example.com/token"
+                    },
+                    new AuthLogoutService2
+                    {
+                        Id = "https://example.com/logout",
+                        Label = new LanguageMap("en", "Logout from Example Institution")
+                    }
+                }
+            }
+        };
 
+
+        [Fact]
+        public void ImageService2_Can_Have_Auth_Services()
+        {
+            // Arrange
+            var imgService2 = new ImageService2
+            {
+                Id = "https://example.com/image/service",
+                Service = auth2Services
             };
-
+            
+            // Act
+            var json = imgService2.AsJson().Replace("\r\n", "\n");
+            const string expected = @"{
+  ""@id"": ""https://example.com/image/service"",
+  ""@type"": ""ImageService2""," + ExpectedService + @"
+}";
+            // Assert
+            json.Should().BeEquivalentTo(expected);
+        }
+        
+        
+        [Fact]
+        public void ImageService3_Can_Have_Auth_Services()
+        {
+            // Arrange
+            var imgService3 = new ImageService3
+            {
+                Id = "https://example.com/image/service",
+                Service = auth2Services
+            };
+            
+            // Act
+            var json = imgService3.AsJson().Replace("\r\n", "\n");
+            const string expected = @"{
+  ""id"": ""https://example.com/image/service"",
+  ""type"": ""ImageService3""," + ExpectedService + @"
+}";
+            // Assert
+            json.Should().BeEquivalentTo(expected);
         }
     }
 }

--- a/src/IIIF/IIIF.Tests/Auth/V2/ImageServiceWithAuthTest.cs
+++ b/src/IIIF/IIIF.Tests/Auth/V2/ImageServiceWithAuthTest.cs
@@ -1,9 +1,6 @@
-using System.Collections.Generic;
 using FluentAssertions;
-using IIIF.Auth.V2;
 using IIIF.ImageApi.V2;
 using IIIF.ImageApi.V3;
-using IIIF.Presentation.V3.Strings;
 using IIIF.Serialisation;
 using Xunit;
 
@@ -11,66 +8,6 @@ namespace IIIF.Tests.Auth.V2
 {
     public class ImageServiceWithAuthTest
     {
-        const string ExpectedService = @"
-  ""service"": [
-    {
-      ""id"": ""https://example.com/image/service/probe"",
-      ""type"": ""AuthProbeService2""
-    },
-    {
-      ""id"": ""https://example.com/login"",
-      ""type"": ""AuthAccessService2"",
-      ""profile"": ""interactive"",
-      ""service"": [
-        {
-          ""id"": ""https://example.com/token"",
-          ""type"": ""AuthTokenService2""
-        },
-        {
-          ""id"": ""https://example.com/logout"",
-          ""type"": ""AuthLogoutService2"",
-          ""label"": {""en"":[""Logout from Example Institution""]}
-        }
-      ],
-      ""confirmLabel"": {""en"":[""ConfirmLabel property""]},
-      ""header"": {""en"":[""Header property""]},
-      ""description"": {""en"":[""Description property""]},
-      ""failureHeader"": {""en"":[""FailureHeader property""]},
-      ""failureDescription"": {""en"":[""FailureDescription property""]}
-    }
-  ]";
-
-        private readonly List<IService> auth2Services = new List<IService>
-        {
-            new AuthProbeService2
-            {
-                Id = "https://example.com/image/service/probe"
-            },
-            new AuthAccessService2
-            {
-                Id = "https://example.com/login",
-                Profile = AuthAccessService2.InteractiveProfile,
-                ConfirmLabel = new LanguageMap("en", "ConfirmLabel property"),
-                Header = new LanguageMap("en", "Header property"),
-                Description = new LanguageMap("en", "Description property"),
-                FailureHeader = new LanguageMap("en", "FailureHeader property"),
-                FailureDescription = new LanguageMap("en", "FailureDescription property"),
-                Service = new List<IService>
-                {
-                    new AuthTokenService2
-                    {
-                        Id = "https://example.com/token"
-                    },
-                    new AuthLogoutService2
-                    {
-                        Id = "https://example.com/logout",
-                        Label = new LanguageMap("en", "Logout from Example Institution")
-                    }
-                }
-            }
-        };
-
-
         [Fact]
         public void ImageService2_Can_Have_Auth_Services()
         {
@@ -78,14 +15,14 @@ namespace IIIF.Tests.Auth.V2
             var imgService2 = new ImageService2
             {
                 Id = "https://example.com/image/service",
-                Service = auth2Services
+                Service = ReusableParts.Auth2Services
             };
             
             // Act
             var json = imgService2.AsJson().Replace("\r\n", "\n");
             const string expected = @"{
   ""@id"": ""https://example.com/image/service"",
-  ""@type"": ""ImageService2""," + ExpectedService + @"
+  ""@type"": ""ImageService2""," + ReusableParts.ExpectedService + @"
 }";
             // Assert
             json.Should().BeEquivalentTo(expected);
@@ -99,14 +36,14 @@ namespace IIIF.Tests.Auth.V2
             var imgService3 = new ImageService3
             {
                 Id = "https://example.com/image/service",
-                Service = auth2Services
+                Service = ReusableParts.Auth2Services
             };
             
             // Act
             var json = imgService3.AsJson().Replace("\r\n", "\n");
             const string expected = @"{
   ""id"": ""https://example.com/image/service"",
-  ""type"": ""ImageService3""," + ExpectedService + @"
+  ""type"": ""ImageService3""," + ReusableParts.ExpectedService + @"
 }";
             // Assert
             json.Should().BeEquivalentTo(expected);

--- a/src/IIIF/IIIF.Tests/Auth/V2/ImageServiceWithAuthTest.cs
+++ b/src/IIIF/IIIF.Tests/Auth/V2/ImageServiceWithAuthTest.cs
@@ -1,0 +1,18 @@
+using IIIF.ImageApi.V2;
+using Xunit;
+
+namespace IIIF.Tests.Auth.V2
+{
+    public class ImageServiceWithAuthTest
+    {
+        [Fact]
+        public void ImageService_Can_Have_Auth_Services()
+        {
+            var imgService = new ImageService2
+            {
+
+            };
+
+        }
+    }
+}

--- a/src/IIIF/IIIF.Tests/Auth/V2/ProbeServiceTests.cs
+++ b/src/IIIF/IIIF.Tests/Auth/V2/ProbeServiceTests.cs
@@ -1,0 +1,114 @@
+using FluentAssertions;
+using IIIF.Auth.V2;
+using IIIF.ImageApi.V2;
+using IIIF.ImageApi.V3;
+using IIIF.Presentation.V3.Content;
+using IIIF.Presentation.V3.Strings;
+using IIIF.Serialisation;
+using Xunit;
+
+namespace IIIF.Tests.Auth.V2
+{
+    public class ProbeServiceTests
+    {
+        [Fact]
+        public void ProbeService_Can_Be_For_External_Resource()
+        {
+            // Arrange
+            var probe = new AuthProbeService2
+            {
+                Id = "https://example.org/resource1/probe",
+                Label = new LanguageMap("en", "A probe Service"),
+                For = new Image
+                {
+                    Id = "https://example.org/resource1"
+                },
+                Location = new Image
+                {
+                    Id = "https://example.org/resource1-open"
+                }
+            };
+            
+            // Act
+            var json = probe.AsJson().Replace("\r\n", "\n");
+            const string expected = @"{
+  ""id"": ""https://example.org/resource1/probe"",
+  ""type"": ""AuthProbeService2"",
+  ""label"": {""en"":[""A probe Service""]},
+  ""for"": {
+    ""id"": ""https://example.org/resource1"",
+    ""type"": ""Image""
+  },
+  ""location"": {
+    ""id"": ""https://example.org/resource1-open"",
+    ""type"": ""Image""
+  }
+}";
+            
+            // Assert
+            json.Should().BeEquivalentTo(expected);
+            
+        }
+        
+        
+        [Fact]
+        public void ProbeService_Can_Be_For_ImageService2()
+        {
+            // Arrange
+            var probe = new AuthProbeService2
+            {
+                Id = "https://example.org/resource1/probe",
+                Label = new LanguageMap("en", "A probe Service"),
+                For = new ImageService2
+                {
+                    Id = "https://example.org/imageService2"
+                }
+            };
+            
+            // Act
+            var json = probe.AsJson().Replace("\r\n", "\n");
+            const string expected = @"{
+  ""id"": ""https://example.org/resource1/probe"",
+  ""type"": ""AuthProbeService2"",
+  ""label"": {""en"":[""A probe Service""]},
+  ""for"": {
+    ""@id"": ""https://example.org/imageService2"",
+    ""@type"": ""ImageService2""
+  }
+}";
+            
+            // Assert
+            json.Should().BeEquivalentTo(expected);
+        }
+        
+        [Fact]
+        public void ProbeService_Can_Be_For_ImageService3()
+        {
+            // Arrange
+            var probe = new AuthProbeService2
+            {
+                Id = "https://example.org/resource1/probe",
+                Label = new LanguageMap("en", "A probe Service"),
+                For = new ImageService3
+                {
+                    Id = "https://example.org/imageService3"
+                }
+            };
+            
+            // Act
+            var json = probe.AsJson().Replace("\r\n", "\n");
+            const string expected = @"{
+  ""id"": ""https://example.org/resource1/probe"",
+  ""type"": ""AuthProbeService2"",
+  ""label"": {""en"":[""A probe Service""]},
+  ""for"": {
+    ""id"": ""https://example.org/imageService3"",
+    ""type"": ""ImageService3""
+  }
+}";
+            
+            // Assert
+            json.Should().BeEquivalentTo(expected);
+        }
+    }
+}

--- a/src/IIIF/IIIF.Tests/Auth/V2/ReusableParts.cs
+++ b/src/IIIF/IIIF.Tests/Auth/V2/ReusableParts.cs
@@ -1,0 +1,68 @@
+using System.Collections.Generic;
+using IIIF.Auth.V2;
+using IIIF.Presentation.V3.Strings;
+
+namespace IIIF.Tests.Auth.V2
+{
+    public class ReusableParts
+    {
+        public const string ExpectedService = @"
+  ""service"": [
+    {
+      ""id"": ""https://example.com/image/service/probe"",
+      ""type"": ""AuthProbeService2""
+    },
+    {
+      ""id"": ""https://example.com/login"",
+      ""type"": ""AuthAccessService2"",
+      ""profile"": ""interactive"",
+      ""service"": [
+        {
+          ""id"": ""https://example.com/token"",
+          ""type"": ""AuthTokenService2""
+        },
+        {
+          ""id"": ""https://example.com/logout"",
+          ""type"": ""AuthLogoutService2"",
+          ""label"": {""en"":[""Logout from Example Institution""]}
+        }
+      ],
+      ""confirmLabel"": {""en"":[""ConfirmLabel property""]},
+      ""header"": {""en"":[""Header property""]},
+      ""description"": {""en"":[""Description property""]},
+      ""failureHeader"": {""en"":[""FailureHeader property""]},
+      ""failureDescription"": {""en"":[""FailureDescription property""]}
+    }
+  ]";
+
+        public static readonly List<IService> Auth2Services = new()
+        {
+            new AuthProbeService2
+            {
+                Id = "https://example.com/image/service/probe"
+            },
+            new AuthAccessService2
+            {
+                Id = "https://example.com/login",
+                Profile = AuthAccessService2.InteractiveProfile,
+                ConfirmLabel = new LanguageMap("en", "ConfirmLabel property"),
+                Header = new LanguageMap("en", "Header property"),
+                Description = new LanguageMap("en", "Description property"),
+                FailureHeader = new LanguageMap("en", "FailureHeader property"),
+                FailureDescription = new LanguageMap("en", "FailureDescription property"),
+                Service = new List<IService>
+                {
+                    new AuthTokenService2
+                    {
+                        Id = "https://example.com/token"
+                    },
+                    new AuthLogoutService2
+                    {
+                        Id = "https://example.com/logout",
+                        Label = new LanguageMap("en", "Logout from Example Institution")
+                    }
+                }
+            }
+        };
+    }
+}

--- a/src/IIIF/IIIF.Tests/Auth/V2/TokenServiceTests.cs
+++ b/src/IIIF/IIIF.Tests/Auth/V2/TokenServiceTests.cs
@@ -1,0 +1,55 @@
+using FluentAssertions;
+using IIIF.Auth.V2;
+using IIIF.Presentation.V3.Strings;
+using IIIF.Serialisation;
+using Xunit;
+
+namespace IIIF.Tests.Auth.V2
+{
+    public class TokenServiceTests
+    {
+        [Fact]
+        public void Token_Service_Success_Response()
+        {
+            // Arrange
+            var tokenResp = new AccessToken2SuccessResponse
+            {
+                AccessToken = "TOKEN_HERE",
+                ExpiresIn = 999,
+                MessageId = "100"
+            };
+            
+            // Act
+            var json = tokenResp.AsJson().Replace("\r\n", "\n");
+            var expected = @"{
+  ""accessToken"": ""TOKEN_HERE"",
+  ""expiresIn"": 999,
+  ""messageId"": ""100""
+}";
+            // Assert
+            json.Should().BeEquivalentTo(expected);
+
+        }
+        
+        [Fact]
+        public void Token_Service_Error_Response()
+        {
+            // Arrange
+            var tokenResp = new AuthTokenError2(
+                AuthTokenError2.InvalidCredentials,
+                new LanguageMap("en", "Your credentials are wrong"));
+            
+            // Act
+            var json = tokenResp.AsJson().Replace("\r\n", "\n");
+            var expected = @"{
+  ""@context"": ""http://iiif.io/api/auth/2/context.json"",
+  ""type"": ""AuthTokenError2"",
+  ""profile"": ""invalidCredentials"",
+  ""description"": {""en"":[""Your credentials are wrong""]}
+}";
+            // Assert
+            json.Should().BeEquivalentTo(expected);
+
+        }
+    }
+}

--- a/src/IIIF/IIIF.Tests/Serialisation/MixedAuthServicesTest.cs
+++ b/src/IIIF/IIIF.Tests/Serialisation/MixedAuthServicesTest.cs
@@ -1,0 +1,109 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using IIIF.Auth.V1;
+using IIIF.ImageApi.V2;
+using IIIF.Presentation.V2.Strings;
+using IIIF.Serialisation;
+using IIIF.Tests.Auth.V2;
+using Xunit;
+
+namespace IIIF.Tests.Serialisation
+{
+    public class MixedAuthServicesTest
+    {
+        [Fact]
+        public void Image2_Can_Have_V1_And_V2_Auth_Services()
+        {
+            // Arrange
+            var auth1CookieService = AuthCookieService.NewClickthroughInstance();
+            auth1CookieService.Id = "https://example.com/login";
+            auth1CookieService.Label = new MetaDataValue("auth1 - label");
+            auth1CookieService.Header = new MetaDataValue("auth1 - header");
+            auth1CookieService.Description = new MetaDataValue("auth1 - desc");
+            auth1CookieService.ConfirmLabel = new MetaDataValue("auth1 - confirm");
+            auth1CookieService.FailureHeader = new MetaDataValue("auth1 - fail");
+            auth1CookieService.FailureDescription = new MetaDataValue("auth1 - fail-desc");
+            auth1CookieService.Service = new List<IService>
+            {
+                new AuthTokenService
+                {
+                    Id = "https://example.com/token"
+                },           
+                new AuthLogoutService
+                {
+                    Id = "https://example.com/logout",
+                    Label = new MetaDataValue("Log out")
+                }
+            };
+            var imgService2 = new ImageService2
+            {
+                Id = "https://example.org/images/my-image.jpg/v2/service",
+                Service = new List<IService> { auth1CookieService }
+            };
+            
+            imgService2.Service.AddRange(ReusableParts.Auth2Services);
+            
+            // Act
+            var json = imgService2.AsJson().Replace("\r\n", "\n");;
+            const string expected = @"{
+  ""@id"": ""https://example.org/images/my-image.jpg/v2/service"",
+  ""@type"": ""ImageService2"",
+  ""service"": [
+    {
+      ""@id"": ""https://example.com/login"",
+      ""@type"": ""AuthCookieService1"",
+      ""profile"": ""http://iiif.io/api/auth/1/clickthrough"",
+      ""label"": ""auth1 - label"",
+      ""description"": ""auth1 - desc"",
+      ""service"": [
+        {
+          ""@id"": ""https://example.com/token"",
+          ""@type"": ""AuthTokenService1"",
+          ""profile"": ""http://iiif.io/api/auth/1/token""
+        },
+        {
+          ""@id"": ""https://example.com/logout"",
+          ""@type"": ""AuthLogoutService1"",
+          ""profile"": ""http://iiif.io/api/auth/1/logout"",
+          ""label"": ""Log out""
+        }
+      ],
+      ""confirmLabel"": ""auth1 - confirm"",
+      ""header"": ""auth1 - header"",
+      ""failureHeader"": ""auth1 - fail"",
+      ""failureDescription"": ""auth1 - fail-desc""
+    },
+    {
+      ""id"": ""https://example.com/image/service/probe"",
+      ""type"": ""AuthProbeService2""
+    },
+    {
+      ""id"": ""https://example.com/login"",
+      ""type"": ""AuthAccessService2"",
+      ""profile"": ""interactive"",
+      ""service"": [
+        {
+          ""id"": ""https://example.com/token"",
+          ""type"": ""AuthTokenService2""
+        },
+        {
+          ""id"": ""https://example.com/logout"",
+          ""type"": ""AuthLogoutService2"",
+          ""label"": {""en"":[""Logout from Example Institution""]}
+        }
+      ],
+      ""confirmLabel"": {""en"":[""ConfirmLabel property""]},
+      ""header"": {""en"":[""Header property""]},
+      ""description"": {""en"":[""Description property""]},
+      ""failureHeader"": {""en"":[""FailureHeader property""]},
+      ""failureDescription"": {""en"":[""FailureDescription property""]}
+    }
+  ]
+}";
+            
+            // Assert
+            json.Should().BeEquivalentTo(expected);
+            
+        }
+    }
+}

--- a/src/IIIF/IIIF.Tests/Serialisation/MixedAuthServicesTest.cs
+++ b/src/IIIF/IIIF.Tests/Serialisation/MixedAuthServicesTest.cs
@@ -44,7 +44,7 @@ namespace IIIF.Tests.Serialisation
             imgService2.Service.AddRange(ReusableParts.Auth2Services);
             
             // Act
-            var json = imgService2.AsJson().Replace("\r\n", "\n");;
+            var json = imgService2.AsJson().Replace("\r\n", "\n");
             const string expected = @"{
   ""@id"": ""https://example.org/images/my-image.jpg/v2/service"",
   ""@type"": ""ImageService2"",

--- a/src/IIIF/IIIF.Tests/Serialisation/MixedVersionSerialisertests.cs
+++ b/src/IIIF/IIIF.Tests/Serialisation/MixedVersionSerialisertests.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using IIIF.ImageApi.V2;
+using IIIF.ImageApi.V3;
+using IIIF.Presentation.V3.Content;
+using IIIF.Serialisation;
+using Xunit;
+
+namespace IIIF.Tests.Serialisation
+{
+    public class MixedVersionSerialiserTests
+    {
+        [Fact]
+        public void Image_Can_Have_V2_And_V3_Image_Services()
+        {
+            // Arrange
+            var img = new Image
+            {
+                Id = $"https://example.org/images/my-image.jpg",
+                Width = 1000,
+                Height = 1000,
+                Format = "image/jpeg",
+                Service = new List<IService>
+                {
+                    new ImageService2
+                    {
+                        Id = "https://example.org/images/my-image.jpg/v2/service"
+                    },
+                    new ImageService3
+                    {
+                        Id = "https://example.org/images/my-image.jpg/v2/service"
+                    }
+                }
+            };
+            
+            // Act
+            var json = img.AsJson().Replace("\r\n", "\n");;
+            const string expected = @"{
+  ""id"": ""https://example.org/images/my-image.jpg"",
+  ""type"": ""Image"",
+  ""width"": 1000,
+  ""height"": 1000,
+  ""format"": ""image/jpeg"",
+  ""service"": [
+    {
+      ""@id"": ""https://example.org/images/my-image.jpg/v2/service"",
+      ""@type"": ""ImageService2""
+    },
+    {
+      ""id"": ""https://example.org/images/my-image.jpg/v2/service"",
+      ""type"": ""ImageService3""
+    }
+  ]
+}";
+            // Assert
+            json.Should().BeEquivalentTo(expected);
+
+        }
+        
+        
+    }
+}

--- a/src/IIIF/IIIF/Auth/V2/AccessToken2ErrorResponse.cs
+++ b/src/IIIF/IIIF/Auth/V2/AccessToken2ErrorResponse.cs
@@ -1,0 +1,31 @@
+using IIIF.Presentation.V3;
+using IIIF.Presentation.V3.Strings;
+using Newtonsoft.Json;
+
+namespace IIIF.Auth.V2
+{
+    public class AuthTokenError2 : ResourceBase
+    {
+        public const string InvalidRequest = "invalidRequest";
+        public const string MissingCredentials = "missingCredentials";
+        public const string InvalidCredentials = "invalidCredentials";
+        public const string ExpiredCredentials = "expiredCredentials";
+        public const string InvalidOrigin = "invalidOrigin";
+        public const string Unavailable = "unavailable";
+        
+        public override string Type => nameof(AuthTokenError2);
+        
+        [JsonProperty(Order = 101, PropertyName = "description")]
+        public LanguageMap? Description { get; set; }
+
+        public AuthTokenError2(string profile, LanguageMap description)
+        {
+            Context = Constants.IIIFAuth2Context;
+            Profile = profile;
+            Description = description;
+        }
+        
+        public AuthTokenError2()
+        { }
+    }
+}

--- a/src/IIIF/IIIF/Auth/V2/AccessToken2SuccessResponse.cs
+++ b/src/IIIF/IIIF/Auth/V2/AccessToken2SuccessResponse.cs
@@ -1,0 +1,16 @@
+using Newtonsoft.Json;
+
+namespace IIIF.Auth.V2
+{
+    public class AccessToken2SuccessResponse
+    {
+        [JsonProperty(Order = 10, PropertyName = "accessToken")]
+        public string? AccessToken { get; set; }
+        
+        [JsonProperty(Order = 20, PropertyName = "expiresIn")]
+        public int? ExpiresIn { get; set; }
+        
+        [JsonProperty(Order = 30, PropertyName = "messageId")]
+        public string? MessageId { get; set; }
+    }
+}

--- a/src/IIIF/IIIF/Auth/V2/AccessToken2SuccessResponse.cs
+++ b/src/IIIF/IIIF/Auth/V2/AccessToken2SuccessResponse.cs
@@ -2,7 +2,7 @@ using Newtonsoft.Json;
 
 namespace IIIF.Auth.V2
 {
-    public class AccessToken2SuccessResponse
+    public class AccessToken2SuccessResponse : JsonLdBase
     {
         [JsonProperty(Order = 10, PropertyName = "accessToken")]
         public string? AccessToken { get; set; }

--- a/src/IIIF/IIIF/Auth/V2/AuthAccessService2.cs
+++ b/src/IIIF/IIIF/Auth/V2/AuthAccessService2.cs
@@ -1,0 +1,30 @@
+using IIIF.Presentation.V3;
+using IIIF.Presentation.V3.Strings;
+using Newtonsoft.Json;
+
+namespace IIIF.Auth.V2
+{
+    public class AuthAccessService2 : ResourceBase, IService
+    {
+        public const string InteractiveProfile = "interactive";
+        public const string KioskProfile = "kiosk";
+        public const string ExternalProfile = "external";
+        
+        public override string Type => nameof(AuthAccessService2);
+
+        [JsonProperty(Order = 101, PropertyName = "confirmLabel")]
+        public LanguageMap? ConfirmLabel { get; set; }
+
+        [JsonProperty(Order = 102, PropertyName = "header")]
+        public LanguageMap? Header { get; set; }
+        
+        [JsonProperty(Order = 103, PropertyName = "description")]
+        public LanguageMap? Description { get; set; }
+        
+        [JsonProperty(Order = 104, PropertyName = "failureHeader")]
+        public LanguageMap? FailureHeader { get; set; }
+        
+        [JsonProperty(Order = 105, PropertyName = "failureDescription")]
+        public LanguageMap? FailureDescription { get; set; }
+    }
+}

--- a/src/IIIF/IIIF/Auth/V2/AuthLogoutService2.cs
+++ b/src/IIIF/IIIF/Auth/V2/AuthLogoutService2.cs
@@ -1,0 +1,9 @@
+using IIIF.Presentation.V3;
+
+namespace IIIF.Auth.V2
+{
+    public class AuthLogoutService2 : ResourceBase, IService
+    {
+        public override string Type => nameof(AuthLogoutService2);
+    }
+}

--- a/src/IIIF/IIIF/Auth/V2/AuthProbeService2.cs
+++ b/src/IIIF/IIIF/Auth/V2/AuthProbeService2.cs
@@ -1,0 +1,17 @@
+using IIIF.Presentation.V3;
+using IIIF.Presentation.V3.Content;
+using Newtonsoft.Json;
+
+namespace IIIF.Auth.V2
+{
+    public class AuthProbeService2 : ResourceBase
+    {
+        public override string Type => nameof(AuthProbeService2);
+        
+        [JsonProperty(Order = 101, PropertyName = "for")]
+        public JsonLdBase? For { get; set; }
+        
+        [JsonProperty(Order = 102, PropertyName = "location")]
+        public JsonLdBase? Location { get; set; }
+    }
+}

--- a/src/IIIF/IIIF/Auth/V2/AuthTokenService2.cs
+++ b/src/IIIF/IIIF/Auth/V2/AuthTokenService2.cs
@@ -1,0 +1,9 @@
+using IIIF.Presentation.V3;
+
+namespace IIIF.Auth.V2
+{
+    public class AuthTokenService2 : ResourceBase, IService
+    {
+        public override string Type => nameof(AuthTokenService2);
+    }
+}

--- a/src/IIIF/IIIF/Auth/V2/Constants.cs
+++ b/src/IIIF/IIIF/Auth/V2/Constants.cs
@@ -1,0 +1,7 @@
+namespace IIIF.Auth.V2
+{
+    public class Constants
+    {
+        public const string IIIFAuth2Context = "http://iiif.io/api/auth/2/context.json";
+    }
+}


### PR DESCRIPTION
New set of classes to allow Auth2 in IIIF resources.

Includes serialisation tests to make sure they can be used together.

Also added a test to demonstrate Image1 and Image2 together.

One interesting nugget from this is the probe service `for` and `location` properties, which can point to Image Services or Content Resources. The type of this property had to be `JsonLdBase` - there's no more specialised common base class.

I think this is OK though.