### PR TITLE
Add nullable annotations to Search V1 classes

### DIFF
--- a/src/IIIF/IIIF/Search/IHasIgnorableParameters.cs
+++ b/src/IIIF/IIIF/Search/IHasIgnorableParameters.cs
@@ -2,6 +2,6 @@
 {
     public interface IHasIgnorableParameters
     {
-        string[] Ignored { get; set; }
+        string[]? Ignored { get; set; }
     }
 }

--- a/src/IIIF/IIIF/Search/V1/Hit.cs
+++ b/src/IIIF/IIIF/Search/V1/Hit.cs
@@ -12,20 +12,18 @@ namespace IIIF.Search.V1
         }
 
         [JsonProperty(Order = 40, PropertyName = "annotations")]
-        public string[] Annotations { get; set; }
+        public string[]? Annotations { get; set; }
 
         [JsonProperty(Order = 50, PropertyName = "match")]
-        public string Match { get; set; }
+        public string? Match { get; set; }
 
         [JsonProperty(Order = 51, PropertyName = "before")]
-        public string Before { get; set; }
+        public string? Before { get; set; }
 
         [JsonProperty(Order = 52, PropertyName = "after")]
-        public string After { get; set; }
+        public string? After { get; set; }
 
-        // Not used for Wellcome
         [JsonProperty(Order = 60, PropertyName = "selectors")]
-
-        public TextQuoteSelector[] Selectors { get; set; }
+        public TextQuoteSelector[]? Selectors { get; set; }
     }
 }

--- a/src/IIIF/IIIF/Search/V1/SearchResultAnnotationList.cs
+++ b/src/IIIF/IIIF/Search/V1/SearchResultAnnotationList.cs
@@ -7,18 +7,18 @@ namespace IIIF.Search.V1
     public class SearchResultAnnotationList : AnnotationList
     {
         [JsonProperty(Order = 10, PropertyName = "within")]
-        public SearchResultsLayer Within { get; set; }
+        public SearchResultsLayer? Within { get; set; }
 
         [JsonProperty(Order = 12, PropertyName = "previous")]
-        public string Previous { get; set; }
+        public string? Previous { get; set; }
 
         [JsonProperty(Order = 13, PropertyName = "next")]
-        public string Next { get; set; }
+        public string? Next { get; set; }
 
         [JsonProperty(Order = 16, PropertyName = "startIndex")]
-        public int StartIndex { get; set; }
+        public int? StartIndex { get; set; }
 
         [JsonProperty(Order = 30, PropertyName = "hits")]
-        public Hit[] Hits { get; set; }
+        public Hit[]? Hits { get; set; }
     }
 }

--- a/src/IIIF/IIIF/Search/V1/SearchResultsLayer.cs
+++ b/src/IIIF/IIIF/Search/V1/SearchResultsLayer.cs
@@ -15,15 +15,15 @@ namespace IIIF.Search.V1
         }
 
         [JsonProperty(Order = 10, PropertyName = "total")]
-        public int Total { get; set; }
+        public int? Total { get; set; }
 
         [JsonProperty(Order = 14, PropertyName = "first")]
-        public string First { get; set; }
+        public string? First { get; set; }
 
         [JsonProperty(Order = 15, PropertyName = "last")]
-        public string Last { get; set; }
+        public string? Last { get; set; }
 
         [JsonProperty(Order = 20, PropertyName = "ignored")]
-        public string[] Ignored { get; set; }
+        public string[]? Ignored { get; set; }
     }
 }

--- a/src/IIIF/IIIF/Search/V1/Term.cs
+++ b/src/IIIF/IIIF/Search/V1/Term.cs
@@ -5,16 +5,16 @@ namespace IIIF.Search.V1
     public class Term
     {
         [JsonProperty(Order = 11, PropertyName = "match")]
-        public string Match { get; set; }
+        public string? Match { get; set; }
 
         // Hide for now, Wellcome don't know this
         //[JsonProperty(Order = 12, PropertyName = "total")]
         //public int Total { get; set; }
 
         [JsonProperty(Order = 13, PropertyName = "label")]
-        public string Label { get; set; }
+        public string? Label { get; set; }
 
         [JsonProperty(Order = 14, PropertyName = "search")]
-        public string Search { get; set; }
+        public string? Search { get; set; }
     }
 }

--- a/src/IIIF/IIIF/Search/V1/TermList.cs
+++ b/src/IIIF/IIIF/Search/V1/TermList.cs
@@ -12,9 +12,9 @@ namespace IIIF.Search.V1
         }
 
         [JsonProperty(Order = 20, PropertyName = "ignored")]
-        public string[] Ignored { get; set; }
+        public string[]? Ignored { get; set; }
 
         [JsonProperty(Order = 40, PropertyName = "terms")]
-        public Term[] Terms { get; set; }
+        public Term[]? Terms { get; set; }
     }
 }

--- a/src/IIIF/IIIF/Search/V1/TextQuoteSelector.cs
+++ b/src/IIIF/IIIF/Search/V1/TextQuoteSelector.cs
@@ -12,12 +12,12 @@ namespace IIIF.Search.V1
         }
 
         [JsonProperty(Order = 51, PropertyName = "exact")]
-        public string Exact { get; set; }
+        public string? Exact { get; set; }
 
         [JsonProperty(Order = 52, PropertyName = "prefix")]
-        public string Prefix { get; set; }
+        public string? Prefix { get; set; }
 
         [JsonProperty(Order = 53, PropertyName = "suffix")]
-        public string Suffix { get; set; }
+        public string? Suffix { get; set; }
     }
 }

--- a/src/IIIF/IIIF/Serialisation/ImageService2Converter.cs
+++ b/src/IIIF/IIIF/Serialisation/ImageService2Converter.cs
@@ -29,7 +29,7 @@ namespace IIIF.Serialisation
             imageService.WriteTo(writer);
         }
 
-        public override ImageService2 ReadJson(JsonReader reader, Type objectType, ImageService2 existingValue, bool hasExistingValue,
+        public override ImageService2 ReadJson(JsonReader reader, Type objectType, ImageService2? existingValue, bool hasExistingValue,
             JsonSerializer serializer)
         {
             var jsonObject = JObject.Load(reader);


### PR DESCRIPTION
Going to confine this change to Search classes only.
We should do the same for other parts of the library, but I think it would be better to wait until we can use the `required` keyword as well as nullable values.