### PR TITLE
Auth2 updates + deserialisation

### DIFF
--- a/src/IIIF/IIIF.Tests/Auth/V2/ContentResourceWithAuthTest.cs
+++ b/src/IIIF/IIIF.Tests/Auth/V2/ContentResourceWithAuthTest.cs
@@ -26,4 +26,21 @@ public class ContentResourceWithAuthTest
         // Assert
         json.Should().BeEquivalentTo(expected);
     }
+    
+    [Fact]
+    public void ContentResource_Deserialise_With_Auth_Services()
+    {
+        // Arrange
+        var res = new ExternalResource("Text")
+        {
+            Id = "https://example.com/documents/my.pdf",
+            Service = ReusableParts.Auth2Services
+        };
+
+        var serialised = res.AsJson();
+
+        // Act
+        var deserialised = serialised.FromJson<ExternalResource>();
+        deserialised.Should().BeEquivalentTo(res);
+    }
 }

--- a/src/IIIF/IIIF.Tests/Auth/V2/ImageServiceWithAuthTest.cs
+++ b/src/IIIF/IIIF.Tests/Auth/V2/ImageServiceWithAuthTest.cs
@@ -26,7 +26,23 @@ public class ImageServiceWithAuthTest
         // Assert
         json.Should().BeEquivalentTo(expected);
     }
+    
+    [Fact]
+    public void ImageService2_Deserialise_With_Auth_Services()
+    {
+        // Arrange
+        var imgService2 = new ImageService2
+        {
+            Id = "https://example.com/image/service",
+            Service = ReusableParts.Auth2Services
+        };
 
+        var serialised = imgService2.AsJson();
+
+        // Act
+        var deserialised = serialised.FromJson<ImageService2>();
+        deserialised.Should().BeEquivalentTo(imgService2);
+    }
 
     [Fact]
     public void ImageService3_Can_Have_Auth_Services()
@@ -46,5 +62,22 @@ public class ImageServiceWithAuthTest
 }";
         // Assert
         json.Should().BeEquivalentTo(expected);
+    }
+    
+    [Fact]
+    public void ImageService3_Deserialise_With_Auth_Services()
+    {
+        // Arrange
+        var imgService3 = new ImageService3
+        {
+            Id = "https://example.com/image/service",
+            Service = ReusableParts.Auth2Services
+        };
+
+        var serialised = imgService3.AsJson();
+
+        // Act
+        var deserialised = serialised.FromJson<ImageService3>();
+        deserialised.Should().BeEquivalentTo(imgService3);
     }
 }

--- a/src/IIIF/IIIF.Tests/Auth/V2/ProbeServiceTests.cs
+++ b/src/IIIF/IIIF.Tests/Auth/V2/ProbeServiceTests.cs
@@ -168,7 +168,7 @@ public class ProbeServiceTests
     {
       ""id"": ""https://example.com/auth/access"",
       ""type"": ""AuthAccessService2"",
-      ""profile"": ""interactive"",
+      ""profile"": ""active"",
       ""label"": {""en"":[""label value""]},
       ""confirmlabel"": {""en"":[""confirmLabel value""]},
       ""heading"": {""en"":[""heading value""]},

--- a/src/IIIF/IIIF.Tests/Auth/V2/ProbeServiceTests.cs
+++ b/src/IIIF/IIIF.Tests/Auth/V2/ProbeServiceTests.cs
@@ -149,7 +149,7 @@ public class ProbeServiceTests
                 new AuthAccessService2
                 {
                     Id = "https://example.com/auth/access",
-                    Profile = AuthAccessService2.InteractiveProfile,
+                    Profile = AuthAccessService2.ActiveProfile,
                     Label = new LanguageMap("en", "label value"),
                     Heading = new LanguageMap("en", "heading value"),
                     Note = new LanguageMap("en", "note value"),

--- a/src/IIIF/IIIF.Tests/Auth/V2/ProbeServiceTests.cs
+++ b/src/IIIF/IIIF.Tests/Auth/V2/ProbeServiceTests.cs
@@ -38,6 +38,24 @@ public class ProbeServiceTests
         json.Should().BeEquivalentTo(expected);
     }
 
+    [Fact]
+    public void ProbeService_CanDeserialiseSerialised()
+    {
+        // Arrange
+        var probe = new AuthProbeService2
+        {
+            Id = "https://example.org/resource1/probe",
+            Label = new LanguageMap("en", "A probe Service"),
+            ErrorHeading = new LanguageMap("en", "errorHeading value"),
+            ErrorNote = new LanguageMap("en", "errorNote value")
+        };
+        
+        var serialised = probe.AsJson();
+
+        // Act
+        var deserialised = serialised.FromJson<AuthProbeService2>();
+        deserialised.Should().BeEquivalentTo(probe);
+    }
 
     [Fact]
     public void ProbeServiceResult_Can_Substitute_ImageService2()
@@ -46,9 +64,12 @@ public class ProbeServiceTests
         var probe = new AuthProbeResult2
         {
             Status = 401,
-            Substitute = new ImageService2
+            Substitute = new List<IService>
             {
-                Id = "https://example.org/imageService2"
+                new ImageService2
+                {
+                    Id = "https://example.org/imageService2"
+                }
             },
             Heading = new LanguageMap("en", "heading value"),
             Note = new LanguageMap("en", "note value")
@@ -60,16 +81,43 @@ public class ProbeServiceTests
   ""@context"": ""http://iiif.io/api/auth/2/context.json"",
   ""type"": ""AuthProbeResult2"",
   ""status"": 401,
-  ""substitute"": {
-    ""@id"": ""https://example.org/imageService2"",
-    ""@type"": ""ImageService2""
-  },
+  ""substitute"": [
+    {
+      ""@id"": ""https://example.org/imageService2"",
+      ""@type"": ""ImageService2""
+    }
+  ],
   ""heading"": {""en"":[""heading value""]},
   ""note"": {""en"":[""note value""]}
 }";
 
         // Assert
         json.Should().BeEquivalentTo(expected);
+    }
+    
+    [Fact]
+    public void ProbeServiceResult_Can_Deserialise_SubstituteImageService2()
+    {
+        // Arrange
+        var probe = new AuthProbeResult2
+        {
+            Status = 401,
+            Substitute = new List<IService>
+            {
+                new ImageService2
+                {
+                    Id = "https://example.org/imageService2"
+                }
+            },
+            Heading = new LanguageMap("en", "heading value"),
+            Note = new LanguageMap("en", "note value")
+        };
+
+        var serialised = probe.AsJson();
+
+        // Act
+        var deserialised = serialised.FromJson<AuthProbeResult2>();
+        deserialised.Should().BeEquivalentTo(probe);
     }
 
     [Fact]
@@ -79,9 +127,12 @@ public class ProbeServiceTests
         var probe = new AuthProbeResult2
         {
             Status = 401,
-            Substitute = new ImageService3
+            Substitute = new List<IService>
             {
-                Id = "https://example.org/imageService3"
+                new ImageService3
+                {
+                    Id = "https://example.org/imageService3"
+                }
             },
             Heading = new LanguageMap("en", "heading value"),
             Note = new LanguageMap("en", "note value")
@@ -93,10 +144,12 @@ public class ProbeServiceTests
   ""@context"": ""http://iiif.io/api/auth/2/context.json"",
   ""type"": ""AuthProbeResult2"",
   ""status"": 401,
-  ""substitute"": {
-    ""id"": ""https://example.org/imageService3"",
-    ""type"": ""ImageService3""
-  },
+  ""substitute"": [
+    {
+      ""id"": ""https://example.org/imageService3"",
+      ""type"": ""ImageService3""
+    }
+  ],
   ""heading"": {""en"":[""heading value""]},
   ""note"": {""en"":[""note value""]}
 }";
@@ -104,7 +157,56 @@ public class ProbeServiceTests
         // Assert
         json.Should().BeEquivalentTo(expected);
     }
+    
+    [Fact]
+    public void ProbeServiceResult_Can_Deserialise_SubstituteImageService3()
+    {
+        // Arrange
+        var probe = new AuthProbeResult2
+        {
+            Status = 401,
+            Substitute = new List<IService>
+            {
+                new ImageService3
+                {
+                    Id = "https://example.org/imageService3"
+                }
+            },
+            Heading = new LanguageMap("en", "heading value"),
+            Note = new LanguageMap("en", "note value")
+        };
 
+        var serialised = probe.AsJson();
+
+        // Act
+        var deserialised = serialised.FromJson<AuthProbeResult2>();
+        deserialised.Should().BeEquivalentTo(probe);
+    }
+    
+    [Fact]
+    public void ProbeServiceResult_Can_Deserialise_SubstituteVideo()
+    {
+        // Arrange
+        var probe = new AuthProbeResult2
+        {
+            Status = 401,
+            Substitute = new List<IService>
+            {
+                new Video
+                {
+                    Id = "https://example.org/video/12345/file.m3u8"
+                }
+            },
+            Heading = new LanguageMap("en", "heading value"),
+            Note = new LanguageMap("en", "note value")
+        };
+
+        var serialised = probe.AsJson();
+
+        // Act
+        var deserialised = serialised.FromJson<AuthProbeResult2>();
+        deserialised.Should().BeEquivalentTo(probe);
+    }
 
     [Fact]
     public void ProbeService_Can_Provide_Location()
@@ -134,7 +236,26 @@ public class ProbeServiceTests
         // Assert
         json.Should().BeEquivalentTo(expected);
     }
+    
+    [Fact]
+    public void ProbeService_Can_Deserialise_WithLocation()
+    {
+        // Arrange
+        var probeResult2 = new AuthProbeResult2
+        {
+            Status = 200,
+            Location = new Video
+            {
+                Id = "https://example.org/video/12345/file.m3u8"
+            }
+        };
 
+        var serialised = probeResult2.AsJson();
+
+        // Act
+        var deserialised = serialised.FromJson<AuthProbeResult2>();
+        deserialised.Should().BeEquivalentTo(probeResult2);
+    }
 
     [Fact]
     public void ProbeService_Can_Provide_AccessService()
@@ -179,5 +300,34 @@ public class ProbeServiceTests
 
         // Assert
         json.Should().BeEquivalentTo(expected);
+    }
+    
+    [Fact]
+    public void ProbeService_Can_Deserialise_AccessService()
+    {
+        // Arrange
+        var probe = new AuthProbeService2
+        {
+            Id = "https://example.org/resource1/probe",
+            Label = new LanguageMap("en", "A probe service"),
+            Service = new List<IService>
+            {
+                new AuthAccessService2
+                {
+                    Id = "https://example.com/auth/access",
+                    Profile = AuthAccessService2.ActiveProfile,
+                    Label = new LanguageMap("en", "label value"),
+                    Heading = new LanguageMap("en", "heading value"),
+                    Note = new LanguageMap("en", "note value"),
+                    ConfirmLabel = new LanguageMap("en", "confirmLabel value")
+                }
+            }
+        };
+
+        var serialised = probe.AsJson();
+
+        // Act
+        var deserialised = serialised.FromJson<AuthProbeService2>();
+        deserialised.Should().BeEquivalentTo(probe);
     }
 }

--- a/src/IIIF/IIIF.Tests/Auth/V2/ReusableParts.cs
+++ b/src/IIIF/IIIF.Tests/Auth/V2/ReusableParts.cs
@@ -13,7 +13,7 @@ public class ReusableParts
         {
           ""id"": ""https://example.com/login"",
           ""type"": ""AuthAccessService2"",
-          ""profile"": ""interactive"",
+          ""profile"": ""active"",
           ""label"": {""en"":[""label property""]},
           ""service"": [
             {

--- a/src/IIIF/IIIF.Tests/Auth/V2/ReusableParts.cs
+++ b/src/IIIF/IIIF.Tests/Auth/V2/ReusableParts.cs
@@ -54,7 +54,7 @@ public class ReusableParts
                 new AuthAccessService2
                 {
                     Id = "https://example.com/login",
-                    Profile = AuthAccessService2.InteractiveProfile,
+                    Profile = AuthAccessService2.ActiveProfile,
                     Label = new LanguageMap("en", "label property"),
                     ConfirmLabel = new LanguageMap("en", "confirmLabel property"),
                     Heading = new LanguageMap("en", "heading property"),

--- a/src/IIIF/IIIF.Tests/Auth/V2/TokenServiceTests.cs
+++ b/src/IIIF/IIIF.Tests/Auth/V2/TokenServiceTests.cs
@@ -31,6 +31,24 @@ public class TokenServiceTests
         // Assert
         json.Should().BeEquivalentTo(expected);
     }
+    
+    [Fact]
+    public void Token_Service_Deserialise_Success_Response()
+    {
+        // Arrange
+        var tokenResp = new AuthAccessToken2
+        {
+            AccessToken = "TOKEN_HERE",
+            ExpiresIn = 999,
+            MessageId = "100"
+        };
+
+        var serialised = tokenResp.AsJson();
+
+        // Act
+        var deserialised = serialised.FromJson<AuthAccessToken2>();
+        deserialised.Should().BeEquivalentTo(tokenResp);
+    }
 
     [Fact]
     public void Token_Service_Error_Response()
@@ -50,5 +68,20 @@ public class TokenServiceTests
 }";
         // Assert
         json.Should().BeEquivalentTo(expected);
+    }
+    
+    [Fact]
+    public void Token_Service_Deserialise_Error_Response()
+    {
+        // Arrange
+        var tokenResp = new AuthAccessTokenError2(
+            AuthAccessTokenError2.InvalidAspect,
+            new LanguageMap("en", "Your credentials are wrong"));
+
+        var serialised = tokenResp.AsJson();
+
+        // Act
+        var deserialised = serialised.FromJson<AuthAccessTokenError2>();
+        deserialised.Should().BeEquivalentTo(tokenResp);
     }
 }

--- a/src/IIIF/IIIF.Tests/Serialisation/MixedAuthServicesTest.cs
+++ b/src/IIIF/IIIF.Tests/Serialisation/MixedAuthServicesTest.cs
@@ -80,7 +80,7 @@ public class MixedAuthServicesTest
         {
           ""id"": ""https://example.com/login"",
           ""type"": ""AuthAccessService2"",
-          ""profile"": ""interactive"",
+          ""profile"": ""active"",
           ""label"": {""en"":[""label property""]},
           ""service"": [
             {

--- a/src/IIIF/IIIF.Tests/Serialisation/MixedAuthServicesTest.cs
+++ b/src/IIIF/IIIF.Tests/Serialisation/MixedAuthServicesTest.cs
@@ -105,4 +105,43 @@ public class MixedAuthServicesTest
         // Assert
         json.Should().BeEquivalentTo(expected);
     }
+    
+    [Fact]
+    public void CanDeserialise_Image2_With_V1_And_V2_Auth_Services()
+    {
+        // Arrange
+        var auth1CookieService = AuthCookieService.NewClickthroughInstance();
+        auth1CookieService.Id = "https://example.com/login";
+        auth1CookieService.Label = new MetaDataValue("auth1 - label");
+        auth1CookieService.Header = new MetaDataValue("auth1 - header");
+        auth1CookieService.Description = new MetaDataValue("auth1 - desc");
+        auth1CookieService.ConfirmLabel = new MetaDataValue("auth1 - confirm");
+        auth1CookieService.FailureHeader = new MetaDataValue("auth1 - fail");
+        auth1CookieService.FailureDescription = new MetaDataValue("auth1 - fail-desc");
+        auth1CookieService.Service = new List<IService>
+        {
+            new AuthTokenService
+            {
+                Id = "https://example.com/token"
+            },
+            new AuthLogoutService
+            {
+                Id = "https://example.com/logout",
+                Label = new MetaDataValue("Log out")
+            }
+        };
+        var imgService2 = new ImageService2
+        {
+            Id = "https://example.org/images/my-image.jpg/v2/service",
+            Service = new List<IService> { auth1CookieService }
+        };
+
+        imgService2.Service.AddRange(ReusableParts.Auth2Services);
+
+        var serialised = imgService2.AsJson();
+
+        // Act
+        var deserialised = serialised.FromJson<ImageService2>();
+        deserialised.Should().BeEquivalentTo(imgService2);
+    }
 }

--- a/src/IIIF/IIIF/Auth/V2/AuthAccessService2.cs
+++ b/src/IIIF/IIIF/Auth/V2/AuthAccessService2.cs
@@ -5,18 +5,27 @@ namespace IIIF.Auth.V2;
 
 public class AuthAccessService2 : ResourceBase, IService
 {
-    public const string InteractiveProfile = "interactive";
+    public const string ActiveProfile = "active";
     public const string KioskProfile = "kiosk";
     public const string ExternalProfile = "external";
 
     public override string Type => nameof(AuthAccessService2);
 
+    /// <summary>
+    /// The label for the user interface element that opens the access service.
+    /// </summary>
     [JsonProperty(Order = 101, PropertyName = "confirmLabel")]
     public LanguageMap? ConfirmLabel { get; set; }
 
+    /// <summary>
+    /// Heading text to be shown with the user interface element that opens the access service.
+    /// </summary>
     [JsonProperty(Order = 102, PropertyName = "heading")]
     public LanguageMap? Heading { get; set; }
 
+    /// <summary>
+    /// Additional text to be shown with the user interface element that opens the access service.
+    /// </summary>
     [JsonProperty(Order = 103, PropertyName = "note")]
     public LanguageMap? Note { get; set; }
 }

--- a/src/IIIF/IIIF/Auth/V2/AuthAccessToken2.cs
+++ b/src/IIIF/IIIF/Auth/V2/AuthAccessToken2.cs
@@ -9,10 +9,10 @@ public class AuthAccessToken2 : JsonLdBase
     public string Type => nameof(AuthAccessToken2);
 
     [JsonProperty(Order = 10, PropertyName = "messageId")]
-    public string? MessageId { get; set; }
+    public string MessageId { get; set; }
 
     [JsonProperty(Order = 20, PropertyName = "accessToken")]
-    public string? AccessToken { get; set; }
+    public string AccessToken { get; set; }
 
     [JsonProperty(Order = 30, PropertyName = "expiresIn")]
     public int? ExpiresIn { get; set; }

--- a/src/IIIF/IIIF/Auth/V2/AuthAccessTokenError2.cs
+++ b/src/IIIF/IIIF/Auth/V2/AuthAccessTokenError2.cs
@@ -5,11 +5,35 @@ namespace IIIF.Auth.V2;
 
 public class AuthAccessTokenError2 : ResourceBase
 {
+    /// <summary>
+    /// The service could not process the access token request.
+    /// </summary>
     public const string InvalidRequest = "invalidRequest";
+    
+    /// <summary>
+    /// The request came from a different origin than that specified in the access service request, or an origin that
+    /// the server rejects for other reasons.
+    /// </summary>
     public const string InvalidOrigin = "invalidOrigin";
+    
+    /// <summary>
+    /// The access token request did not have the required authorizing aspect.
+    /// </summary>
     public const string MissingAspect = "missingAspect";
+    
+    /// <summary>
+    /// The access token request had the aspect used for authorization but it was not valid.
+    /// </summary>
     public const string InvalidAspect = "invalidAspect";
+    
+    /// <summary>
+    /// The request had credentials that are no longer valid for the service.
+    /// </summary>
     public const string ExpiredAspect = "expiredAspect";
+    
+    /// <summary>
+    /// The request could not be fulfilled for reasons other than those listed above, such as scheduled maintenance.
+    /// </summary>
     public const string Unavailable = "unavailable";
 
     public override string Type => nameof(AuthAccessTokenError2);
@@ -20,7 +44,7 @@ public class AuthAccessTokenError2 : ResourceBase
     [JsonProperty(Order = 102, PropertyName = "note")]
     public LanguageMap? Note { get; set; }
 
-    public AuthAccessTokenError2(string profile, LanguageMap note)
+    public AuthAccessTokenError2(string profile, LanguageMap? note = null)
     {
         Context = Constants.IIIFAuth2Context;
         Profile = profile;

--- a/src/IIIF/IIIF/Auth/V2/AuthProbeResult2.cs
+++ b/src/IIIF/IIIF/Auth/V2/AuthProbeResult2.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using IIIF.Presentation.V3.Strings;
 
 namespace IIIF.Auth.V2;
@@ -14,10 +15,10 @@ public class AuthProbeResult2 : JsonLdBase
     public int Status { get; set; }
 
     [JsonProperty(Order = 20, PropertyName = "substitute")]
-    public JsonLdBase? Substitute { get; set; }
+    public List<IService>? Substitute { get; set; }
 
     [JsonProperty(Order = 40, PropertyName = "location")]
-    public JsonLdBase? Location { get; set; }
+    public IService? Location { get; set; }
 
     [JsonProperty(Order = 50, PropertyName = "heading")]
     public LanguageMap? Heading { get; set; }

--- a/src/IIIF/IIIF/Auth/V2/AuthProbeResult2.cs
+++ b/src/IIIF/IIIF/Auth/V2/AuthProbeResult2.cs
@@ -11,7 +11,7 @@ public class AuthProbeResult2 : JsonLdBase
     public string Type => nameof(AuthProbeResult2);
 
     [JsonProperty(Order = 10, PropertyName = "status")]
-    public int? Status { get; set; }
+    public int Status { get; set; }
 
     [JsonProperty(Order = 20, PropertyName = "substitute")]
     public JsonLdBase? Substitute { get; set; }

--- a/src/IIIF/IIIF/Presentation/V3/Content/ExternalResource.cs
+++ b/src/IIIF/IIIF/Presentation/V3/Content/ExternalResource.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using IIIF.Presentation.V3.Annotation;
-using Newtonsoft.Json;
 
 namespace IIIF.Presentation.V3.Content;
 

--- a/src/IIIF/IIIF/Presentation/V3/Content/Image.cs
+++ b/src/IIIF/IIIF/Presentation/V3/Content/Image.cs
@@ -1,5 +1,4 @@
 ﻿using IIIF.Presentation.V3.Annotation;
-using Newtonsoft.Json;
 
 namespace IIIF.Presentation.V3.Content;
 

--- a/src/IIIF/IIIF/Presentation/V3/ResourceBase.cs
+++ b/src/IIIF/IIIF/Presentation/V3/ResourceBase.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using IIIF.Presentation.V3.Content;
 using IIIF.Presentation.V3.Strings;
-using Newtonsoft.Json;
 
 namespace IIIF.Presentation.V3;
 

--- a/src/IIIF/IIIF/Serialisation/Deserialisation/ExternalResourceConverter.cs
+++ b/src/IIIF/IIIF/Serialisation/Deserialisation/ExternalResourceConverter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using IIIF.Auth.V2;
 using IIIF.Presentation.V3.Content;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;

--- a/src/IIIF/IIIF/Serialisation/Deserialisation/ResourceBaseV3Converter.cs
+++ b/src/IIIF/IIIF/Serialisation/Deserialisation/ResourceBaseV3Converter.cs
@@ -50,6 +50,7 @@ public class ResourceBaseV3Converter : ReadOnlyConverter<ResourceBase>
             nameof(Manifest) => new Manifest(),
             nameof(SpecificResource) => new SpecificResource(),
             nameof(AuthProbeService2) => new AuthProbeService2(),
+            nameof(AuthAccessTokenError2) => new AuthAccessTokenError2(),
             nameof(TextualBody) => new TextualBody(jsonObject["value"].Value<string>()),
             _ => null
         };

--- a/src/IIIF/IIIF/Serialisation/Deserialisation/ResourceBaseV3Converter.cs
+++ b/src/IIIF/IIIF/Serialisation/Deserialisation/ResourceBaseV3Converter.cs
@@ -1,9 +1,9 @@
 ﻿using System;
+using IIIF.Auth.V2;
 using IIIF.ImageApi.V3;
 using IIIF.Presentation.V3;
 using IIIF.Presentation.V3.Annotation;
 using IIIF.Presentation.V3.Content;
-using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace IIIF.Serialisation.Deserialisation;
@@ -49,6 +49,7 @@ public class ResourceBaseV3Converter : ReadOnlyConverter<ResourceBase>
             nameof(Image) => new Image(),
             nameof(Manifest) => new Manifest(),
             nameof(SpecificResource) => new SpecificResource(),
+            nameof(AuthProbeService2) => new AuthProbeService2(),
             nameof(TextualBody) => new TextualBody(jsonObject["value"].Value<string>()),
             _ => null
         };

--- a/src/IIIF/IIIF/Serialisation/Deserialisation/ServiceConverter.cs
+++ b/src/IIIF/IIIF/Serialisation/Deserialisation/ServiceConverter.cs
@@ -1,7 +1,8 @@
 ﻿using System;
+using IIIF.Auth.V2;
 using IIIF.ImageApi.V2;
 using IIIF.ImageApi.V3;
-using Newtonsoft.Json;
+using IIIF.Presentation.V3.Content;
 using Newtonsoft.Json.Linq;
 
 namespace IIIF.Serialisation.Deserialisation;
@@ -44,6 +45,14 @@ public class ServiceConverter : ReadOnlyConverter<IService>
                 service = type.Value<string>() switch
                 {
                     nameof(ImageService3) => new ImageService3(),
+                    nameof(AuthAccessService2) => new AuthAccessService2(),
+                    nameof(AuthAccessTokenError2) => new AuthAccessTokenError2(),
+                    nameof(AuthAccessTokenService2) => new AuthAccessTokenService2(),
+                    nameof(AuthLogoutService2) => new AuthLogoutService2(),
+                    nameof(AuthProbeService2) => new AuthProbeService2(),
+                    nameof(Audio) => new Audio(),
+                    nameof(Video) => new Video(),
+                    nameof(Image) => new Image(),
                     _ => null
                 };
         }


### PR DESCRIPTION
Fixes #23 

Made the following changes to Auth2 models based on finalised spec:
* `AuthAccessService2` has `"active"` profile, rather than `"interactive"`.
* Modified `AuthProbeResult2`:
  * `Status` is now required
  * `Substitute` is a list and `IService` rather than `JsonLdBase`.
  * `Location` is `IService` rather than `JsonLdBase`
* `AuthAccessTokenError2` constructor takes optional `LanguageMap` as note is optional.
* `AccessToken` and `MessageId` are required for `AuthAccessToken2`

Added deserialisation tests - these are basic tests verifying that we can deserialise the output of existing serialisation tests.