### PR TITLE
Allow `ImageRequest.Parse` to optionally reject bad parameters

### DIFF
--- a/src/IIIF/IIIF.Tests/ImageApi/ImageRequestXTests.cs
+++ b/src/IIIF/IIIF.Tests/ImageApi/ImageRequestXTests.cs
@@ -240,10 +240,10 @@ public class ImageRequestXTests
     {
         // Arrange and Act
         const string prefix = "iiif-img/27/1/";
-        var action = () => ImageRequest.Parse($"{prefix}my-asset/info.json", prefix);
+        var result = ImageRequest.Parse($"{prefix}my-asset/info.json", prefix);
         
         // Assert
-        action.Should().NotThrow<ArgumentException>();
+        result.IsInformationRequest.Should().BeTrue();
     }
     
     [Fact]
@@ -262,14 +262,14 @@ public class ImageRequestXTests
     [InlineData("/iiif-img/27/1/")]
     [InlineData("/iiif-img/27/1")]
     [InlineData("iiif-img/27/1")]
-    public void Parse_Validate_Succeeds(string prefix)
+    public void Parse_Validate_HandlesPrefixFormats(string prefix)
     {
         // Arrange and Act
         const string request = $"iiif-img/27/1/my-asset/full/800,/0/default.jpg";
         var action = () => ImageRequest.Parse(request, prefix, true);
         
         // Assert
-        action.Should().NotThrow();
+        action.Should().NotThrow<ArgumentException>();
     }
     
     [Theory]
@@ -284,7 +284,8 @@ public class ImageRequestXTests
         var action = () => ImageRequest.Parse($"{prefix}{path}", prefix, true);
         
         // Assert
-        action.Should().ThrowExactly<ArgumentException>();
+        action.Should().ThrowExactly<ArgumentException>()
+            .WithMessage("Path contains empty or an invalid number of segments");
     }
     
     [Theory]
@@ -301,6 +302,7 @@ public class ImageRequestXTests
         var action = () => ImageRequest.Parse($"{prefix}{path}", prefix, true);
         
         // Assert
-        action.Should().ThrowExactly<ArgumentException>();
+        action.Should().ThrowExactly<ArgumentException>()
+            .WithMessage("Path contains empty or an invalid number of segments");
     }
 }

--- a/src/IIIF/IIIF.Tests/ImageApi/ImageRequestXTests.cs
+++ b/src/IIIF/IIIF.Tests/ImageApi/ImageRequestXTests.cs
@@ -234,6 +234,28 @@ public class ImageRequestXTests
         // Assert
         result.IsBase.Should().BeTrue();
     }
+    
+    [Fact]
+    public void Parse_InfoJson()
+    {
+        // Arrange and Act
+        const string prefix = "iiif-img/27/1/";
+        var action = () => ImageRequest.Parse($"{prefix}my-asset/info.json", prefix);
+        
+        // Assert
+        action.Should().NotThrow<ArgumentException>();
+    }
+    
+    [Fact]
+    public void Parse_Fails_WhenInfoHasInvalidExtension()
+    {
+        // Arrange and Act
+        const string prefix = "iiif-img/27/1/";
+        var action = () => ImageRequest.Parse($"{prefix}my-asset/info.jsonll", prefix);
+        
+        // Assert
+        action.Should().ThrowExactly<ArgumentException>();
+    }
 
     [Theory]
     [InlineData("iiif-img/27/1/")]
@@ -272,7 +294,7 @@ public class ImageRequestXTests
     [InlineData("my-asset/full/800,/0/")]
     [InlineData("my-asset////default.jpg")]
     [InlineData("my-asset////")]
-    public void Parse_TryParse_Fails_WhenGivenEmptyParameters(string path)
+    public void Parse_Validate_Fails_WhenGivenEmptyParameters(string path)
     {
         // Arrange and Act
         const string prefix = "iiif-img/27/1/";

--- a/src/IIIF/IIIF/ImageApi/ImageRequest.cs
+++ b/src/IIIF/IIIF/ImageApi/ImageRequest.cs
@@ -44,6 +44,7 @@ public class ImageRequest
         var parts = path.Split('/');
         
         request.Identifier = parts[0];
+        
         if (parts.Length == 1 || (parts.Length == 2 && parts[1] == string.Empty))
         {
             // likely the server will want to redirect this

--- a/src/IIIF/IIIF/ImageApi/ImageRequest.cs
+++ b/src/IIIF/IIIF/ImageApi/ImageRequest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 
 namespace IIIF.ImageApi;
 
@@ -25,7 +26,7 @@ public class ImageRequest
     /// </summary>
     public string ImageRequestPath => OriginalPath.Replace(Identifier, string.Empty);
 
-    public static ImageRequest Parse(string path, string prefix)
+    public static ImageRequest Parse(string path, string prefix, bool validateSegments = false)
     {
         if (path[0] == '/') path = path[1..];
 
@@ -35,12 +36,15 @@ public class ImageRequest
             if (prefix != path[..prefix.Length])
                 throw new ArgumentException("Path does not start with prefix", nameof(prefix));
             path = path[prefix.Length..];
+            if (path[0] == '/') path = path[1..];
         }
 
         var request = new ImageRequest { Prefix = prefix };
+        
         var parts = path.Split('/');
+        
         request.Identifier = parts[0];
-        if (parts.Length == 1 || parts[1] == string.Empty)
+        if (parts.Length == 1 || (parts.Length == 2 && parts[1] == string.Empty))
         {
             // likely the server will want to redirect this
             request.IsBase = true;
@@ -51,6 +55,11 @@ public class ImageRequest
         {
             request.IsInformationRequest = true;
             return request;
+        }
+        
+        if (validateSegments && (parts.Length != 5 || parts.Any(string.IsNullOrEmpty)))
+        {
+            throw new ArgumentException("Path contains empty or an invalid number of parameters");
         }
 
         request.OriginalPath = path;

--- a/src/IIIF/IIIF/ImageApi/ImageRequest.cs
+++ b/src/IIIF/IIIF/ImageApi/ImageRequest.cs
@@ -26,6 +26,14 @@ public class ImageRequest
     /// </summary>
     public string ImageRequestPath => OriginalPath.Replace(Identifier, string.Empty);
 
+    /// <summary>
+    /// Parses an image request path as a IIIF ImageRequest object
+    /// </summary>
+    /// <returns>A ImageRequest object</returns>
+    /// <param name="path">The image request path</param>
+    /// <param name="prefix">The image request prefix</param>
+    /// <param name="validateSegments">If true, throws an ArgumentException if the image request contains empty values,
+    /// or an invalid number of segments</param>
     public static ImageRequest Parse(string path, string prefix, bool validateSegments = false)
     {
         if (path[0] == '/') path = path[1..];
@@ -60,7 +68,7 @@ public class ImageRequest
         
         if (validateSegments && (parts.Length != 5 || parts.Any(string.IsNullOrEmpty)))
         {
-            throw new ArgumentException("Path contains empty or an invalid number of parameters");
+            throw new ArgumentException("Path contains empty or an invalid number of segments");
         }
 
         request.OriginalPath = path;


### PR DESCRIPTION
This PR adds an optional parameter to `ImageRequest.Parse` that determines if an exception should be thrown when bad parameters - i.e, routes with extra segments (`.../iiif-img//1/2/my-asset/full/800,/0/default.jpg`) or missing parameters (`.../iiif-img/1/2/my-asset//800,//default.jpg`) - is passed.