### PR TITLE
Add `SizeParameter.Resize()` extension

### DIFF
--- a/src/IIIF/IIIF.Tests/ImageApi/SizeParameterX.cs
+++ b/src/IIIF/IIIF.Tests/ImageApi/SizeParameterX.cs
@@ -1,0 +1,250 @@
+﻿using System;
+using IIIF.ImageApi;
+
+namespace IIIF.Tests.ImageApi;
+
+public class SizeParameterX
+{
+    [Theory]
+    [InlineData(100, 100, "max", 100, 100, "Square")]
+    [InlineData(50, 100, "max", 50, 100, "Portrait")]
+    [InlineData(100, 50, "max", 100, 50, "Landscape")]
+    public void Resize_Max(int w, int h, string sizeParam, int expectedW, int expectedH, string test)
+    {
+        // Arrange
+        var sp = SizeParameter.Parse(sizeParam);
+        var size = new Size(w, h);
+        var expected = new Size(expectedW, expectedH);
+        
+        // Act
+        var actual = sp.Resize(size);
+        
+        // Assert
+        actual.Should().BeEquivalentTo(expected, test);
+    }
+    
+    [Fact]
+    public void Resize_UpscaleMax()
+    {
+        // Arrange
+        var sp = SizeParameter.Parse("^max");
+        var size = new Size(1, 1);
+        
+        // Act
+        Action action = () => sp.Resize(size);
+        
+        // Assert
+        action.Should().Throw<NotSupportedException>()
+            .WithMessage("^max is not supported as maxWidth, maxHeight or maxArea unknown");
+    }
+    
+    [Theory]
+    [InlineData(100, 100, "50,", 50, 50, "Square")]
+    [InlineData(50, 100, "50,", 50, 100, "Portrait")]
+    [InlineData(100, 50, "50,", 50, 25, "Landscape")]
+    [InlineData(100, 100, "200,", 100, 100, "Square larger")]
+    [InlineData(50, 100, "200,", 50, 100, "Portrait larger")]
+    [InlineData(100, 50, "200,", 100, 50, "Landscape larger")]
+    public void Resize_Width(int w, int h, string sizeParam, int expectedW, int expectedH, string test)
+    {
+        // Arrange
+        var sp = SizeParameter.Parse(sizeParam);
+        var size = new Size(w, h);
+        var expected = new Size(expectedW, expectedH);
+        
+        // Act
+        var actual = sp.Resize(size);
+        
+        // Assert
+        actual.Should().BeEquivalentTo(expected, test);
+    }
+    
+    [Theory]
+    [InlineData(100, 100, "^50,", 50, 50, "Square")]
+    [InlineData(50, 100, "^50,", 50, 100, "Portrait")]
+    [InlineData(100, 50, "^50,", 50, 25, "Landscape")]
+    [InlineData(100, 100, "^200,", 200, 200, "Square larger")]
+    [InlineData(50, 100, "^200,", 200, 400, "Portrait larger")]
+    [InlineData(100, 50, "^200,", 200, 100, "Landscape larger")]
+    public void Resize_UpscaleWidth(int w, int h, string sizeParam, int expectedW, int expectedH, string test)
+    {
+        // Arrange
+        var sp = SizeParameter.Parse(sizeParam);
+        var size = new Size(w, h);
+        var expected = new Size(expectedW, expectedH);
+        
+        // Act
+        var actual = sp.Resize(size);
+        
+        // Assert
+        actual.Should().BeEquivalentTo(expected, test);
+    }
+    
+    [Theory]
+    [InlineData(100, 100, ",50", 50, 50, "Square")]
+    [InlineData(50, 100, ",50", 25, 50, "Portrait")]
+    [InlineData(100, 50, ",50", 100, 50, "Landscape")]
+    [InlineData(100, 100, ",200", 100, 100, "Square larger")]
+    [InlineData(50, 100, ",200", 50, 100, "Portrait larger")]
+    [InlineData(100, 50, ",200", 100, 50, "Landscape larger")]
+    public void Resize_Height(int w, int h, string sizeParam, int expectedW, int expectedH, string test)
+    {
+        // Arrange
+        var sp = SizeParameter.Parse(sizeParam);
+        var size = new Size(w, h);
+        var expected = new Size(expectedW, expectedH);
+        
+        // Act
+        var actual = sp.Resize(size);
+        
+        // Assert
+        actual.Should().BeEquivalentTo(expected, test);
+    }
+    
+    [Theory]
+    [InlineData(100, 100, "^,50", 50, 50, "Square")]
+    [InlineData(50, 100, "^,50", 25, 50, "Portrait")]
+    [InlineData(100, 50, "^,50", 100, 50, "Landscape")]
+    [InlineData(100, 100, "^,200", 200, 200, "Square larger")]
+    [InlineData(50, 100, "^,200", 100, 200, "Portrait larger")]
+    [InlineData(100, 50, "^,200", 400, 200, "Landscape larger")]
+    public void Resize_UpscaleHeight(int w, int h, string sizeParam, int expectedW, int expectedH, string test)
+    {
+        // Arrange
+        var sp = SizeParameter.Parse(sizeParam);
+        var size = new Size(w, h);
+        var expected = new Size(expectedW, expectedH);
+        
+        // Act
+        var actual = sp.Resize(size);
+        
+        // Assert
+        actual.Should().BeEquivalentTo(expected, test);
+    }
+    
+    [Theory]
+    [InlineData(100, 100, "pct:50", 50, 50, "Square")]
+    [InlineData(50, 100, "pct:50", 25, 50, "Portrait")]
+    [InlineData(100, 50, "pct:50", 50, 25, "Landscape")]
+    [InlineData(100, 100, "pct:200", 100, 100, "Square larger")]
+    [InlineData(50, 100, "pct:200", 50, 100, "Portrait larger")]
+    [InlineData(100, 50, "pct:200", 100, 50, "Landscape larger")]
+    public void Resize_Percent(int w, int h, string sizeParam, int expectedW, int expectedH, string test)
+    {
+        // Arrange
+        var sp = SizeParameter.Parse(sizeParam);
+        var size = new Size(w, h);
+        var expected = new Size(expectedW, expectedH);
+        
+        // Act
+        var actual = sp.Resize(size);
+        
+        // Assert
+        actual.Should().BeEquivalentTo(expected, test);
+    }
+    
+    [Theory]
+    [InlineData(100, 100, "^pct:50", 50, 50, "Square")]
+    [InlineData(50, 100, "^pct:50", 25, 50, "Portrait")]
+    [InlineData(100, 50, "^pct:50", 50, 25, "Landscape")]
+    [InlineData(100, 100, "^pct:200", 200, 200, "Square larger")]
+    [InlineData(50, 100, "^pct:200", 100, 200, "Portrait larger")]
+    [InlineData(100, 50, "^pct:200", 200, 100, "Landscape larger")]
+    public void Resize_UpscalePercent(int w, int h, string sizeParam, int expectedW, int expectedH, string test)
+    {
+        // Arrange
+        var sp = SizeParameter.Parse(sizeParam);
+        var size = new Size(w, h);
+        var expected = new Size(expectedW, expectedH);
+        
+        // Act
+        var actual = sp.Resize(size);
+        
+        // Assert
+        actual.Should().BeEquivalentTo(expected, test);
+    }
+    
+    [Theory]
+    [InlineData(100, 100, "50,50", 50, 50, "Square")]
+    [InlineData(50, 100, "50,50", 50, 50, "Portrait")]
+    [InlineData(100, 50, "50,50", 50, 50, "Landscape")]
+    [InlineData(100, 100, "200,200", 100, 100, "Square larger")]
+    [InlineData(50, 100, "200,200", 50, 100, "Portrait larger")]
+    [InlineData(100, 50, "200,200", 100, 50, "Landscape larger")]
+    public void Resize_WidthHeight(int w, int h, string sizeParam, int expectedW, int expectedH, string test)
+    {
+        // Arrange
+        var sp = SizeParameter.Parse(sizeParam);
+        var size = new Size(w, h);
+        var expected = new Size(expectedW, expectedH);
+        
+        // Act
+        var actual = sp.Resize(size);
+        
+        // Assert
+        actual.Should().BeEquivalentTo(expected, test);
+    }
+    
+    [Theory]
+    [InlineData(100, 100, "^50,50", 50, 50, "Square")]
+    [InlineData(50, 100, "^50,50", 50, 50, "Portrait")]
+    [InlineData(100, 50, "^50,50", 50, 50, "Landscape")]
+    [InlineData(100, 100, "^200,200", 200, 200, "Square larger")]
+    [InlineData(50, 100, "^200,200", 200, 200, "Portrait larger")]
+    [InlineData(100, 50, "^200,200", 200, 200, "Landscape larger")]
+    public void Resize_UpscaleWidthHeight(int w, int h, string sizeParam, int expectedW, int expectedH, string test)
+    {
+        // Arrange
+        var sp = SizeParameter.Parse(sizeParam);
+        var size = new Size(w, h);
+        var expected = new Size(expectedW, expectedH);
+        
+        // Act
+        var actual = sp.Resize(size);
+        
+        // Assert
+        actual.Should().BeEquivalentTo(expected, test);
+    }
+    
+    [Theory]
+    [InlineData(100, 100, "!50,50", 50, 50, "Square")]
+    [InlineData(50, 100, "!50,50", 25, 50, "Portrait")]
+    [InlineData(100, 50, "!50,50", 50, 25, "Landscape")]
+    [InlineData(100, 100, "!200,200", 100, 100, "Square larger")]
+    [InlineData(50, 100, "!200,200", 50, 100, "Portrait larger")]
+    [InlineData(100, 50, "!200,200", 100, 50, "Landscape larger")]
+    public void Resize_ConfinedWidthHeight(int w, int h, string sizeParam, int expectedW, int expectedH, string test)
+    {
+        // Arrange
+        var sp = SizeParameter.Parse(sizeParam);
+        var size = new Size(w, h);
+        var expected = new Size(expectedW, expectedH);
+        
+        // Act
+        var actual = sp.Resize(size);
+        
+        // Assert
+        actual.Should().BeEquivalentTo(expected, test);
+    }
+    
+    [Theory]
+    [InlineData(100, 100, "^!50,50", 50, 50, "Square")]
+    [InlineData(50, 100, "^!50,50", 25, 50, "Portrait")]
+    [InlineData(100, 50, "^!50,50", 50, 25, "Landscape")]
+    [InlineData(100, 100, "^!200,200", 200, 200, "Square larger")]
+    [InlineData(50, 100, "^!200,200", 100, 200, "Portrait larger")]
+    [InlineData(100, 50, "^!200,200", 200, 100, "Landscape larger")]
+    public void Resize_UpscaleConfinedWidthHeight(int w, int h, string sizeParam, int expectedW, int expectedH, string test)
+    {
+        // Arrange
+        var sp = SizeParameter.Parse(sizeParam);
+        var size = new Size(w, h);
+        var expected = new Size(expectedW, expectedH);
+        
+        // Act
+        var actual = sp.Resize(size);
+        
+        // Assert
+        actual.Should().BeEquivalentTo(expected, test);
+    }
+}

--- a/src/IIIF/IIIF.Tests/ImageApi/SizeTests.cs
+++ b/src/IIIF/IIIF.Tests/ImageApi/SizeTests.cs
@@ -368,7 +368,7 @@ public class SizeTests
         new TestSizeData(500, 400, 300, 300, 300, 240), // current portrait
         new TestSizeData(400, 500, 300, 300, 240, 300), // current landscape
         new TestSizeData(500, 500, 300, 200, 200, 200), // target portrait
-        new TestSizeData(500, 500, 200, 300, 200, 300), // target landscape
+        new TestSizeData(500, 500, 200, 300, 200, 200), // target landscape
         new TestSizeData(4553, 5668, 200, 200, 161, 200) // a specific rounding issue with Appetiser
     };
 
@@ -390,10 +390,8 @@ public class SizeTests
     {
         get
         {
-            var data = sampleTestData.Where(d => d.ConfineWidth == d.ConfineHeight);
-
             var retVal = new List<object[]>();
-            retVal.AddRange(data.Select(sizeData => new object[] { sizeData }));
+            retVal.AddRange(sampleTestData.Select(sizeData => new object[] { sizeData }));
             return retVal;
         }
     }

--- a/src/IIIF/IIIF/ImageApi/SizeParameterX.cs
+++ b/src/IIIF/IIIF/ImageApi/SizeParameterX.cs
@@ -1,0 +1,54 @@
+﻿using System;
+
+namespace IIIF.ImageApi;
+
+public static class SizeParameterX
+{
+    /// <summary>
+    /// Resize given size in accordance with <see cref="SizeParameter"/>
+    /// Note that /^max/ is not supported.
+    /// If ^ is not specified and size larger than image the largest possible size is returned.
+    /// </summary>  
+    public static Size Resize(this SizeParameter sizeParameter, Size size)
+    {
+        // /max/
+        if (sizeParameter.Max)
+        {
+            if (sizeParameter.Upscaled)
+            {
+                throw new NotSupportedException("^max is not supported as maxWidth, maxHeight or maxArea unknown");
+            }
+
+            return size;
+        }
+
+        // /pct:n/ /^pct:n/
+        if (sizeParameter.PercentScale.HasValue)
+        {
+            var percent = sizeParameter.Upscaled
+                ? sizeParameter.PercentScale.Value
+                : Math.Min(sizeParameter.PercentScale.Value, 100);
+            return Size.ResizePercent(size, percent);
+        }
+        
+        // /!w,h/ /^!w,h/
+        if (sizeParameter.Confined)
+        {
+            var requiredSize = new Size(sizeParameter.Width!.Value, sizeParameter.Height!.Value);
+            return sizeParameter.Upscaled
+                ? Size.FitWithin(requiredSize, size)
+                : Size.Confine(requiredSize, size);
+        }
+        
+        // /w,/ /^w,/ /,h/ /^,h/ /w,h/ /^w,h/ 
+        var width = sizeParameter.Width;
+        var height = sizeParameter.Height;
+
+        if (!sizeParameter.Upscaled)
+        {
+            width = sizeParameter.Width.HasValue ? Math.Min(size.Width, sizeParameter.Width.Value) : null;
+            height = sizeParameter.Height.HasValue ? Math.Min(size.Height, sizeParameter.Height.Value) : null;
+        }
+        return Size.Resize(size, width, height);
+    }
+}


### PR DESCRIPTION
Helper method for `SizeParameter` that will resize given `Size` according to param values.

This is accordance to [IIIF ImageApi 3](https://iiif.io/api/image/3.0/#42-size).

All values are supported with the exception of `^max` as we don't know `maxWidth`, `maxHeight` or `maxArea`. 

Note that this method is forgiving - for `w,`, `,h`, `pct:n` and `w,h` where the values _"MUST NOT be greater than XX"_ this method will not throw an exception but will instead return the largest possible size.

e.g. Image 200x200 and SizeParamter `/500,/` will return 200x200.