### PR TITLE
Add ability to deserialize collections correctly

### DIFF
--- a/src/IIIF/IIIF.Tests/Serialisation/CollectionSerializationTests.cs
+++ b/src/IIIF/IIIF.Tests/Serialisation/CollectionSerializationTests.cs
@@ -1,0 +1,104 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using IIIF.Presentation.V3;
+using IIIF.Presentation.V3.Content;
+using IIIF.Presentation.V3.Strings;
+using IIIF.Serialisation;
+
+namespace IIIF.Tests.Serialisation;
+
+public class CollectionSerializationTests
+{
+    private Collection sampleCollection = new()
+    {
+        Id = $"someId",
+        Context = "http://iiif.io/api/presentation/3/context.json",
+        Label = new LanguageMap
+        {
+            {"en", new List<string>
+            {
+                "root"
+            }}
+        },
+        Behavior = new List<string>
+        {
+            "some-behaviour"
+        },
+        Items = new List<ICollectionItem>
+        {
+            new Collection
+            {
+                Id = "child",
+                Label = new LanguageMap
+                {
+                    {"en", new List<string>
+                    {
+                        "child"
+                    }}
+                }
+            },
+            new Manifest
+            {
+                Id = "child",
+                Label = new LanguageMap
+                {
+                    {"en", new List<string>
+                    {
+                        "child manifest"
+                    }}
+                }
+            }
+        },
+        PartOf = new List<ResourceBase>
+        { 
+            new ExternalResource("Collection")
+            {
+                Id = $"PartOf",
+                Label = new LanguageMap
+                {
+                    {"en", new List<string>
+                    {
+                        "some collection"
+                    }}
+                }
+            }
+        },
+        SeeAlso = new List<ExternalResource>
+        {
+            new ("SeeAlso")
+            {
+                Id = "see also",
+                Label = new LanguageMap
+                {
+                    {"en", new List<string>
+                    {
+                        "child"
+                    }}
+                },
+                Profile = "Public"
+            }
+        },
+    };
+    
+    [Fact]
+    public void CanDeserialiseSerialisedCollection()
+    {
+        var serialisedCollection = sampleCollection.AsJson();
+
+        var deserialised = serialisedCollection.FromJson<Collection>();
+
+        deserialised.Should().BeEquivalentTo(sampleCollection);
+    }
+    
+    [Fact]
+    public void CanDeserialiseSerialisedCollection_Stream()
+    {
+        using var memoryStream = new MemoryStream();
+        sampleCollection.AsJsonStream(memoryStream);
+
+        memoryStream.Position = 0;
+        var deserialised = memoryStream.FromJsonStream<Collection>();
+
+        deserialised.Should().BeEquivalentTo(sampleCollection);
+    }
+}

--- a/src/IIIF/IIIF/Serialisation/Deserialisation/CollectionItemConverter.cs
+++ b/src/IIIF/IIIF/Serialisation/Deserialisation/CollectionItemConverter.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using IIIF.Presentation.V3;
+using Newtonsoft.Json.Linq;
+
+namespace IIIF.Serialisation.Deserialisation;
+
+public class CollectionItemConverter : ReadOnlyConverter<ICollectionItem>
+{
+    public override ICollectionItem? ReadJson(JsonReader reader, Type objectType, ICollectionItem? existingValue, bool hasExistingValue,
+        JsonSerializer serializer)
+    {
+        var jsonObject = JObject.Load(reader);
+
+        ICollectionItem collectionItem = jsonObject["type"].Value<string>() switch
+        {
+            nameof(Collection) => new Collection(),
+            nameof(Manifest) => new Manifest(),
+            _ => new Collection()
+        };
+
+        serializer.Populate(jsonObject.CreateReader(), collectionItem);
+        return collectionItem;
+    }
+}

--- a/src/IIIF/IIIF/Serialisation/Deserialisation/CollectionItemConverter.cs
+++ b/src/IIIF/IIIF/Serialisation/Deserialisation/CollectionItemConverter.cs
@@ -15,7 +15,7 @@ public class CollectionItemConverter : ReadOnlyConverter<ICollectionItem>
         {
             nameof(Collection) => new Collection(),
             nameof(Manifest) => new Manifest(),
-            _ => new Collection()
+            _ => null
         };
 
         serializer.Populate(jsonObject.CreateReader(), collectionItem);

--- a/src/IIIF/IIIF/Serialisation/IIIFSerialiserX.cs
+++ b/src/IIIF/IIIF/Serialisation/IIIFSerialiserX.cs
@@ -32,7 +32,7 @@ public static class IIIFSerialiserX
         {
             new ImageService2Converter(), new AnnotationV3Converter(), new ResourceBaseV3Converter(),
             new StructuralLocationConverter(), new ExternalResourceConverter(), new PaintableConverter(),
-            new SelectorConverter(), new ServiceConverter(), new ResourceConverter(),
+            new SelectorConverter(), new ServiceConverter(), new ResourceConverter(), new CollectionItemConverter()
         }
     };
 


### PR DESCRIPTION
This pull request allows the `Collection` type to be deserialized correctly, by adding a `CollectionItemConverter` to for converting `ICollectionItem` types.