### PR TITLE
Expand serialization customisation options

### DIFF
--- a/src/IIIF/IIIF/IIIF.csproj
+++ b/src/IIIF/IIIF/IIIF.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
         <PackageId>iiif-net</PackageId>
+        <LangVersion>10.0</LangVersion>
         <Authors>Donald Gray,Tom Crane</Authors>
         <Company>Digirati</Company>
         <Description>IIIF Library for .NET Core</Description>

--- a/src/IIIF/IIIF/Serialisation/IIIFSerialiserX.cs
+++ b/src/IIIF/IIIF/Serialisation/IIIFSerialiserX.cs
@@ -10,7 +10,7 @@ namespace IIIF.Serialisation;
 /// </summary>
 public static class IIIFSerialiserX
 {
-    private static readonly JsonSerializerSettings SerializerSettings = new()
+    public static JsonSerializerSettings SerializerSettings { get; set; } = new()
     {
         NullValueHandling = NullValueHandling.Ignore,
         ContractResolver = new PrettyIIIFContractResolver(),
@@ -23,7 +23,7 @@ public static class IIIFSerialiserX
         }
     };
 
-    private static readonly JsonSerializerSettings DeserializerSettings = new()
+    public static JsonSerializerSettings DeserializerSettings { get; set; } = new()
     {
         NullValueHandling = NullValueHandling.Ignore,
         ContractResolver = new PrettyIIIFContractResolver(),

--- a/src/IIIF/IIIF/Serialisation/IIIFSerialiserX.cs
+++ b/src/IIIF/IIIF/Serialisation/IIIFSerialiserX.cs
@@ -30,9 +30,10 @@ public static class IIIFSerialiserX
         Formatting = Formatting.Indented,
         Converters = new List<JsonConverter>
         {
-            new ImageService2Converter(), new AnnotationV3Converter(), new ResourceBaseV3Converter(),
-            new StructuralLocationConverter(), new ExternalResourceConverter(), new PaintableConverter(),
-            new SelectorConverter(), new ServiceConverter(), new ResourceConverter(), new CollectionItemConverter()
+            new ExternalResourceConverter(), new ImageService2Converter(), new AnnotationV3Converter(),
+            new StructuralLocationConverter(), new PaintableConverter(),
+            new SelectorConverter(), new ServiceConverter(), new ResourceBaseV3Converter(),
+            new CollectionItemConverter(), new ResourceConverter()
         }
     };
 


### PR DESCRIPTION
Allows using this package's predetermined `JsonSerializationSettings` by library consumers, as well as overriding it for the library (de)serializers. Additionally allows passing custom (external to the library) types deriving from `ResourceBase` to be recognised during deserialization by `ResourceBaseV3Converter`.

Change in deserialization converter order is in theory a breaking change, but it didn't seem to work correctly beforehand (as per Donald's comments), so take it as you will.

Other changes are opt-in, i.e. have no effect if you don't actively interact with exposed bits.