### PR TITLE
Make iiif-net parse all the Manifests in the Cookbook

### DIFF
--- a/src/IIIF/IIIF.Tests/Serialisation/CookbookDeserialization.cs
+++ b/src/IIIF/IIIF.Tests/Serialisation/CookbookDeserialization.cs
@@ -1,49 +1,17 @@
-using System;
-using System.Collections.Generic;
-using System.Net.Http;
 using IIIF.Presentation.V3;
-using IIIF.Serialisation;
+using IIIF.Tests.Serialisation.Data;
 
 namespace IIIF.Tests.Serialisation;
 
+[Trait("Category", "Cookbook")]
 public class CookbookDeserialization
 {
-    private Collection theseusCollection;
-    private HttpClient httpClient;
-    private List<string> skip;
-    
-    public CookbookDeserialization()
+    [Theory]
+    [ClassData(typeof(CookbookManifestData))]
+    public void Can_Deserialize_Cookbook_Manifest(string manifestId, Manifest manifest)
     {
-        httpClient = new HttpClient();
-        var s = httpClient.GetStringAsync("https://theseus-viewer.netlify.app/cookbook-collection.json").Result;
-        theseusCollection = s.FromJson<Collection>();
-        
-        // these have bugs in the cookbook, see https://github.com/IIIF/cookbook-recipes/pull/546
-        skip = new List<string>
-        {
-            "https://iiif.io/api/cookbook/recipe/0219-using-caption-file/manifest.json",
-            "https://iiif.io/api/cookbook/recipe/0040-image-rotation-service/manifest-service.json"
-        };
+        // perfunctory assertion
+        manifest.Should().NotBeNull();
+        manifest.Id.Should().Be(manifestId);
     }
-
-    [Fact]
-    public void Can_Deserialize_Cookbook_Collection()
-    {
-        foreach (var item in theseusCollection.Items!)
-        {
-            if (item is Manifest manifestRef)
-            {
-                if (!skip.Contains(manifestRef.Id))
-                {
-                    var s = httpClient.GetStringAsync(manifestRef.Id).Result;
-                    var manifest = s.FromJson<Manifest>();
-                    // perfunctory assertion
-                    manifest.Id.Should().Be(manifestRef.Id);
-                }
-            }
-            // Do collections too...
-        }
-        
-    }
-    
 }

--- a/src/IIIF/IIIF.Tests/Serialisation/CookbookDeserialization.cs
+++ b/src/IIIF/IIIF.Tests/Serialisation/CookbookDeserialization.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using IIIF.Presentation.V3;
+using IIIF.Serialisation;
+
+namespace IIIF.Tests.Serialisation;
+
+public class CookbookDeserialization
+{
+    private Collection theseusCollection;
+    private HttpClient httpClient;
+    private List<string> skip;
+    
+    public CookbookDeserialization()
+    {
+        httpClient = new HttpClient();
+        var s = httpClient.GetStringAsync("https://theseus-viewer.netlify.app/cookbook-collection.json").Result;
+        theseusCollection = s.FromJson<Collection>();
+        
+        // these have bugs in the cookbook, see https://github.com/IIIF/cookbook-recipes/pull/546
+        skip = new List<string>
+        {
+            "https://iiif.io/api/cookbook/recipe/0219-using-caption-file/manifest.json",
+            "https://iiif.io/api/cookbook/recipe/0040-image-rotation-service/manifest-service.json"
+        };
+    }
+
+    [Fact]
+    public void Can_Deserialize_Cookbook_Collection()
+    {
+        foreach (var item in theseusCollection.Items!)
+        {
+            if (item is Manifest manifestRef)
+            {
+                if (!skip.Contains(manifestRef.Id))
+                {
+                    var s = httpClient.GetStringAsync(manifestRef.Id).Result;
+                    var manifest = s.FromJson<Manifest>();
+                    // perfunctory assertion
+                    manifest.Id.Should().Be(manifestRef.Id);
+                }
+            }
+            // Do collections too...
+        }
+        
+    }
+    
+}

--- a/src/IIIF/IIIF.Tests/Serialisation/CookbookDeserialization.cs
+++ b/src/IIIF/IIIF.Tests/Serialisation/CookbookDeserialization.cs
@@ -11,7 +11,7 @@ public class CookbookDeserialization
     public void Can_Deserialize_Cookbook_Manifest(string manifestId, Manifest manifest)
     {
         // perfunctory assertion
-        manifest.Should().NotBeNull();
+        manifest.Should().NotBeNull($"{manifestId} is a valid cookbook manifest");
         manifest.Id.Should().Be(manifestId);
     }
 }

--- a/src/IIIF/IIIF.Tests/Serialisation/Data/CookbookManifestData.cs
+++ b/src/IIIF/IIIF.Tests/Serialisation/Data/CookbookManifestData.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Net.Http;
 using IIIF.Presentation.V3;
@@ -43,9 +44,17 @@ public class CookbookManifestData : IEnumerable<object[]>
             var resource = httpClient.GetAsync(url).Result;
             if (mustSucceed) resource.EnsureSuccessStatusCode();
             if (!resource.IsSuccessStatusCode) return null;
-            
-            var iiif = resource.Content.ReadAsStream().FromJsonStream<T>();
-            return iiif;
+
+            try
+            {
+                var iiif = resource.Content.ReadAsStream().FromJsonStream<T>();
+                return iiif;
+            }
+            catch (Exception)
+            {
+                if (mustSucceed) throw;
+                return null;
+            }
         }
     }
 

--- a/src/IIIF/IIIF.Tests/Serialisation/Data/CookbookManifestData.cs
+++ b/src/IIIF/IIIF.Tests/Serialisation/Data/CookbookManifestData.cs
@@ -1,0 +1,55 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Net.Http;
+using IIIF.Presentation.V3;
+using IIIF.Serialisation;
+
+namespace IIIF.Tests.Serialisation.Data;
+
+/// <summary>
+/// Used as [ClassData] - contains Manifests from IIIF Cookbook to validate deserialisation
+/// </summary>
+public class CookbookManifestData : IEnumerable<object[]>
+{
+    // This will store { manifest-id, deserialized-manifest }
+    private readonly List<object[]> data = new();
+    
+    // these have bugs in the cookbook, see https://github.com/IIIF/cookbook-recipes/pull/546
+    private List<string> skip = new()
+    {
+        "https://iiif.io/api/cookbook/recipe/0219-using-caption-file/manifest.json",
+        "https://iiif.io/api/cookbook/recipe/0040-image-rotation-service/manifest-service.json"
+    };
+    
+    public CookbookManifestData()
+    {
+        using var httpClient = new HttpClient();
+        var theseusCollection =
+            GetIIIFResource<Collection>("https://theseus-viewer.netlify.app/cookbook-collection.json", true);
+
+        foreach (var item in theseusCollection.Items!)
+        {
+            if (item is Manifest manifestRef)
+            {
+                if (skip.Contains(manifestRef.Id)) continue;
+                
+                var iiif = GetIIIFResource<Manifest>(manifestRef.Id);
+                data.Add(new object[] { manifestRef.Id, iiif });
+            }
+        }
+        
+        T GetIIIFResource<T>(string url, bool mustSucceed = false) where T : JsonLdBase
+        {
+            var resource = httpClient.GetAsync(url).Result;
+            if (mustSucceed) resource.EnsureSuccessStatusCode();
+            if (!resource.IsSuccessStatusCode) return null;
+            
+            var iiif = resource.Content.ReadAsStream().FromJsonStream<T>();
+            return iiif;
+        }
+    }
+
+    public IEnumerator<object[]> GetEnumerator() => data.GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}

--- a/src/IIIF/IIIF/Presentation/V3/Content/Sound.cs
+++ b/src/IIIF/IIIF/Presentation/V3/Content/Sound.cs
@@ -2,11 +2,11 @@
 
 namespace IIIF.Presentation.V3.Content;
 
-public class Audio : ExternalResource, ITemporal, IPaintable
+public class Sound : ExternalResource, ITemporal, IPaintable
 {
     public double? Duration { get; set; }
 
-    public Audio() : base("Sound")
+    public Sound() : base(nameof(Sound))
     {
     }
 }

--- a/src/IIIF/IIIF/Presentation/V3/Selectors/ISource.cs
+++ b/src/IIIF/IIIF/Presentation/V3/Selectors/ISource.cs
@@ -1,0 +1,6 @@
+namespace IIIF.Presentation.V3.Selectors;
+
+public class ISource
+{
+    
+}

--- a/src/IIIF/IIIF/Presentation/V3/Selectors/ISource.cs
+++ b/src/IIIF/IIIF/Presentation/V3/Selectors/ISource.cs
@@ -1,6 +1,0 @@
-namespace IIIF.Presentation.V3.Selectors;
-
-public class ISource
-{
-    
-}

--- a/src/IIIF/IIIF/Presentation/V3/Selectors/SvgSelector.cs
+++ b/src/IIIF/IIIF/Presentation/V3/Selectors/SvgSelector.cs
@@ -1,0 +1,7 @@
+namespace IIIF.Presentation.V3.Selectors;
+
+public class SvgSelector : ISelector
+{
+    public string? Type => nameof(SvgSelector);
+    public string? Value { get; set; }
+}

--- a/src/IIIF/IIIF/Presentation/V3/SpecificResource.cs
+++ b/src/IIIF/IIIF/Presentation/V3/SpecificResource.cs
@@ -1,13 +1,15 @@
-﻿using IIIF.Presentation.V3.Selectors;
-using Newtonsoft.Json;
+﻿using IIIF.Presentation.V3.Annotation;
+using IIIF.Presentation.V3.Selectors;
+using IIIF.Serialisation;
 
 namespace IIIF.Presentation.V3;
 
-public class SpecificResource : ResourceBase, IStructuralLocation
+public class SpecificResource : ResourceBase, IStructuralLocation, IPaintable
 {
     public override string Type => nameof(SpecificResource);
 
-    [JsonProperty(Order = 101)] public string Source { get; set; }
+    [JsonConverter(typeof(SourceConverter))]
+    [JsonProperty(Order = 101)] public IPaintable Source { get; set; }
 
     [JsonProperty(Order = 102)] public ISelector Selector { get; set; }
 }

--- a/src/IIIF/IIIF/Serialisation/Deserialisation/ExternalResourceConverter.cs
+++ b/src/IIIF/IIIF/Serialisation/Deserialisation/ExternalResourceConverter.cs
@@ -19,7 +19,7 @@ public class ExternalResourceConverter : ReadOnlyConverter<ExternalResource>
         var type = jsonObject["type"].Value<string>();
         var externalResource = type switch
         {
-            nameof(Audio) => new Audio(),
+            nameof(Sound) => new Sound(),
             nameof(Video) => new Video(),
             nameof(Image) => new Image(),
             _ => new ExternalResource(type)

--- a/src/IIIF/IIIF/Serialisation/Deserialisation/PaintableConverter.cs
+++ b/src/IIIF/IIIF/Serialisation/Deserialisation/PaintableConverter.cs
@@ -19,11 +19,12 @@ public class PaintableConverter : ReadOnlyConverter<IPaintable>
 
         IPaintable? paintable = jsonObject["type"].Value<string>() switch
         {
-            nameof(Audio) => new Audio(),
+            nameof(Sound) => new Sound(),
             nameof(Video) => new Video(),
             nameof(Image) => new Image(),
             nameof(Canvas) => new Canvas(),
             "Choice" => new PaintingChoice(),
+            nameof(SpecificResource) => new SpecificResource(),
             _ => null
         };
 

--- a/src/IIIF/IIIF/Serialisation/Deserialisation/ResourceBaseV3Converter.cs
+++ b/src/IIIF/IIIF/Serialisation/Deserialisation/ResourceBaseV3Converter.cs
@@ -44,7 +44,7 @@ public class ResourceBaseV3Converter : ReadOnlyConverter<ResourceBase>
             nameof(Annotation) => new Annotation(),
             nameof(AnnotationCollection) => new AnnotationCollection(),
             nameof(AnnotationPage) => new AnnotationPage(),
-            nameof(Audio) => new Audio(),
+            nameof(Sound) => new Sound(),
             nameof(Canvas) => new Canvas(),
             nameof(Collection) => new Collection(),
             nameof(Image) => new Image(),

--- a/src/IIIF/IIIF/Serialisation/Deserialisation/ResourceConverter.cs
+++ b/src/IIIF/IIIF/Serialisation/Deserialisation/ResourceConverter.cs
@@ -50,7 +50,7 @@ public class ResourceConverter : ReadOnlyConverter<IResource>
                     nameof(AuthAccessTokenService2) => new AuthAccessTokenService2(),
                     nameof(AuthLogoutService2) => new AuthLogoutService2(),
                     nameof(AuthProbeService2) => new AuthProbeService2(),
-                    nameof(Audio) => new Audio(),
+                    nameof(Sound) => new Sound(),
                     nameof(Video) => new Video(),
                     nameof(Image) => new Image(),
                     _ => null

--- a/src/IIIF/IIIF/Serialisation/Deserialisation/SelectorConverter.cs
+++ b/src/IIIF/IIIF/Serialisation/Deserialisation/SelectorConverter.cs
@@ -19,8 +19,10 @@ public class SelectorConverter : ReadOnlyConverter<ISelector>
         {
             nameof(AudioContentSelector) => new AudioContentSelector(),
             nameof(ImageApiSelector) => new ImageApiSelector(),
+            "iiif:ImageApiSelector" => new ImageApiSelector(),
             nameof(PointSelector) => new PointSelector(),
-            nameof(VideoContentSelector) => new VideoContentSelector()
+            nameof(VideoContentSelector) => new VideoContentSelector(),
+            nameof(SvgSelector) => new SvgSelector()
         };
 
         serializer.Populate(jsonObject.CreateReader(), selector);

--- a/src/IIIF/IIIF/Serialisation/SourceConverter.cs
+++ b/src/IIIF/IIIF/Serialisation/SourceConverter.cs
@@ -1,45 +1,43 @@
 using System;
 using IIIF.Presentation.V3;
+using IIIF.Presentation.V3.Annotation;
+using IIIF.Presentation.V3.Content;
 using IIIF.Utils;
-using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using Range = IIIF.Presentation.V3.Range;
 
 namespace IIIF.Serialisation;
 
-/// <summary>
-/// <see cref="JsonConverter"/> for <see cref="IStructuralLocation"/> objects.
-/// Serialises Id-only <see cref="Canvas"/> objects to string representation and deserialises back. 
-/// </summary>
-public class TargetConverter : JsonConverter<IStructuralLocation>
+public class SourceConverter : JsonConverter<IPaintable>
 {
-    public override IStructuralLocation? ReadJson(JsonReader reader, Type objectType,
-        IStructuralLocation? existingValue,
-        bool hasExistingValue, JsonSerializer serializer)
+    public override IPaintable? ReadJson(JsonReader reader, Type objectType, IPaintable? existingValue, bool hasExistingValue,
+        JsonSerializer serializer)
     {
         if (reader.TokenType == JsonToken.String)
         {
+            // We do not know that this is a Canvas...
+            // We would need knowledge of the rest of the IIIF Resource
             return new Canvas { Id = reader.Value.ToString() };
         }
         else if (reader.TokenType == JsonToken.StartObject)
         {
             var obj = JObject.Load(reader);
-
             var type = obj["type"].Value<string>();
-            IStructuralLocation structuralLocation = type switch
+            IPaintable paintable = type switch
             {
+                nameof(Sound) => new Sound(),
+                nameof(Video) => new Video(),
+                nameof(Image) => new Image(),
                 nameof(Canvas) => new Canvas(),
-                nameof(Range) => new Range(),
                 nameof(SpecificResource) => new SpecificResource()
             };
-            serializer.Populate(obj.CreateReader(), structuralLocation);
-            return structuralLocation;
+            serializer.Populate(obj.CreateReader(), paintable);
+            return paintable;
         }
 
         return null;
     }
-
-    public override void WriteJson(JsonWriter writer, IStructuralLocation? value, JsonSerializer serializer)
+    
+    public override void WriteJson(JsonWriter writer, IPaintable? value, JsonSerializer serializer)
     {
         if (value is Canvas canvas && (canvas.SerialiseTargetAsId || IsSimpleCanvas(canvas)))
         {
@@ -50,9 +48,10 @@ public class TargetConverter : JsonConverter<IStructuralLocation>
         // Default, pass through behaviour:
         JObject.FromObject(value, serializer).WriteTo(writer);
     }
-
+    
     private static bool IsSimpleCanvas(Canvas canvas)
     {
         return canvas.Width == null && canvas.Duration == null && canvas.Items.IsNullOrEmpty();
     }
+
 }


### PR DESCRIPTION
The IIIF Cookbook:
https://theseus-viewer.netlify.app/cookbook-collection.json
https://iiif.io/api/cookbook/

1. Biggest change here is renaming `Audio` to `Sound` (the latter is correct in the spec). I considered just using the string but it breaks the pattern of using `nameof` to when comparing type values.
2. This needed quite a few tweaks to custom JSON converters and a new `ISource` and `ISourceConverter` for `SpecificResource`
3. Added SvgSelector

When I ran the full test suite there were loads of breaking tests - but they all seem to be string comparisons of expected and actual JSON, when the JSON is actually equivalent.

In the PMC work I used this quite a bit:
https://github.com/lateapexearlyspeed/Lateapexearlyspeed.JsonSchema?tab=readme-ov-file#lateapexearlyspeedxunitassertionjson

(see JsonAssertion.Equivalent)

Should we use something like that?
