### PR TITLE
Add ability to deserialize custom collection items

### DIFF
--- a/src/IIIF/IIIF.Tests/Serialisation/CustomClassSerializationTests.cs
+++ b/src/IIIF/IIIF.Tests/Serialisation/CustomClassSerializationTests.cs
@@ -45,9 +45,70 @@ public class CustomClassSerializationTests
                 },
                 CustomField = "some-custom-field"
             },
-            new CustomItem()
+            new CustomItem
             {
                 Id = "custom-item-child",
+                Label = new LanguageMap
+                {
+                    {"en", new List<string>
+                    {
+                        "child"
+                    }}
+                },
+                CustomField = "some-custom-field"
+            }
+        },
+        PartOf = new List<ResourceBase>
+        { 
+            new ExternalResource("Collection")
+            {
+                Id = $"PartOf",
+                Label = new LanguageMap
+                {
+                    {"en", new List<string>
+                    {
+                        "some collection"
+                    }}
+                }
+            }
+        },
+        SeeAlso = new List<ExternalResource>
+        {
+            new ("SeeAlso")
+            {
+                Id = "see also",
+                Label = new LanguageMap
+                {
+                    {"en", new List<string>
+                    {
+                        "child"
+                    }}
+                },
+                Profile = "Public"
+            }
+        },
+    };
+    
+    private Collection sampleCollectionOnlyInheritance = new()
+    {
+        Id = $"someId",
+        Context = "http://iiif.io/api/presentation/3/context.json",
+        Label = new LanguageMap
+        {
+            {"en", new List<string>
+            {
+                "root"
+            }}
+        },
+        Behavior = new List<string>
+        {
+            "some-behaviour"
+        },
+        Items = new List<ICollectionItem>
+        {
+            new CustomCollectionItem
+            {
+                Id = "child",
                 Label = new LanguageMap
                 {
                     {"en", new List<string>
@@ -95,8 +156,27 @@ public class CustomClassSerializationTests
         var serialisedCollection = sampleCollection.AsJson();
 
         var deserialised = await serialisedCollection.AsJson<Collection>();
+        var itemAsCustomCollection = deserialised.Items[0] as CustomCollectionItem;
+        var itemAsCustomItem = deserialised.Items[1] as CustomItem;
 
         deserialised.Should().BeEquivalentTo(sampleCollection);
+        itemAsCustomCollection.Should().NotBeNull();
+        itemAsCustomItem.Should().NotBeNull();
+    }
+    
+    [Fact]
+    public void CanDeserialiseCustomSerialisedCollectionWithOnlyStandardLibrary()
+    {
+        var serialisedCollection = sampleCollectionOnlyInheritance.AsJson();
+
+        var deserialised = serialisedCollection.FromJson<Collection>();
+        
+        var itemAsCustomCollection = deserialised.Items[0] as CustomCollectionItem;
+        var itemAsCollection = deserialised.Items[0] as Collection;
+
+        deserialised.Should().BeEquivalentTo(sampleCollectionOnlyInheritance);
+        itemAsCustomCollection.Should().BeNull();
+        itemAsCollection.Should().NotBeNull();
     }
 }
 

--- a/src/IIIF/IIIF.Tests/Serialisation/CustomClassSerializationTests.cs
+++ b/src/IIIF/IIIF.Tests/Serialisation/CustomClassSerializationTests.cs
@@ -196,10 +196,16 @@ public static class CustomSerializerX
 
         settings ??= new(IIIFSerialiserX.DeserializerSettings);
         settings.Context = new StreamingContext(StreamingContextStates.Other,
-            new Dictionary<string, Func<JObject, ICollectionItem>>
+            new Dictionary<Type, IDictionary<string, Func<JObject, object>>>
             {
-                { "Collection", p => new CustomCollectionItem() },
-                { "CustomItem", p => new CustomItem() }
+                { 
+                    typeof(ICollectionItem), 
+                    new Dictionary<string, Func<JObject, object>>
+                    {
+                        { "Collection", _ => new CustomCollectionItem() },
+                        { "CustomItem", _ => new CustomItem() }
+                    }
+                }
             });
 
         var serializer = JsonSerializer.Create(settings);

--- a/src/IIIF/IIIF.Tests/Serialisation/CustomClassSerializationTests.cs
+++ b/src/IIIF/IIIF.Tests/Serialisation/CustomClassSerializationTests.cs
@@ -1,0 +1,148 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.Serialization;
+using System.Threading.Tasks;
+using IIIF.Presentation.V3;
+using IIIF.Presentation.V3.Content;
+using IIIF.Presentation.V3.Strings;
+using IIIF.Serialisation;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Collection = IIIF.Presentation.V3.Collection;
+using ResourceBase = IIIF.Presentation.V3.ResourceBase;
+
+namespace IIIF.Tests.Serialisation;
+
+public class CustomClassSerializationTests
+{
+    private Collection sampleCollection = new()
+    {
+        Id = $"someId",
+        Context = "http://iiif.io/api/presentation/3/context.json",
+        Label = new LanguageMap
+        {
+            {"en", new List<string>
+            {
+                "root"
+            }}
+        },
+        Behavior = new List<string>
+        {
+            "some-behaviour"
+        },
+        Items = new List<ICollectionItem>
+        {
+            new CustomCollectionItem
+            {
+                Id = "child",
+                Label = new LanguageMap
+                {
+                    {"en", new List<string>
+                    {
+                        "child"
+                    }}
+                }
+            },
+            new CustomItem()
+            {
+                Id = "custom-item-child",
+                Label = new LanguageMap
+                {
+                    {"en", new List<string>
+                    {
+                        "child"
+                    }}
+                }
+            }
+        },
+        PartOf = new List<ResourceBase>
+        { 
+            new ExternalResource("Collection")
+            {
+                Id = $"PartOf",
+                Label = new LanguageMap
+                {
+                    {"en", new List<string>
+                    {
+                        "some collection"
+                    }}
+                }
+            }
+        },
+        SeeAlso = new List<ExternalResource>
+        {
+            new ("SeeAlso")
+            {
+                Id = "see also",
+                Label = new LanguageMap
+                {
+                    {"en", new List<string>
+                    {
+                        "child"
+                    }}
+                },
+                Profile = "Public"
+            }
+        },
+    };
+    
+    [Fact]
+    public async Task CanDeserialiseCustomSerialisedCollection()
+    {
+        var serialisedCollection = sampleCollection.AsJson();
+
+        var deserialised = await serialisedCollection.AsJson<Collection>();
+
+        deserialised.Should().BeEquivalentTo(sampleCollection);
+    }
+}
+
+public static class CustomSerializerX
+{
+    public static async Task<T?> AsJson<T>(this string content, JsonSerializerSettings? settings = null)
+        where T : JsonLdBase, new()
+    {
+        using var streamReader = new StringReader(content);
+        return await DeserializeStream<T>(settings, streamReader);
+    }
+    
+    private static async Task<T?> DeserializeStream<T>(JsonSerializerSettings? settings, TextReader streamReader)
+        where T : JsonLdBase, new()
+    {
+        await using var jsonReader = new JsonTextReader(streamReader);
+
+        settings ??= new(IIIFSerialiserX.DeserializerSettings);
+        settings.Context = new StreamingContext(StreamingContextStates.Other,
+            new Dictionary<string, Func<JObject, ICollectionItem>>
+            {
+                { "Collection", p => new CustomCollectionItem() },
+                { "CustomItem", p => new CustomItem() }
+            });
+
+        var serializer = JsonSerializer.Create(settings);
+
+        try
+        {
+            var result = new T();
+            serializer.Populate(jsonReader, result);
+            return result;
+        }
+        catch (JsonException)
+        {
+            return default;
+        }
+    }
+}
+
+public class CustomCollectionItem : Collection
+{
+    public string CustomField = "custom";
+}
+
+public class CustomItem : StructureBase, ICollectionItem
+{
+    public string CustomField = "custom";
+    public List<IService> Services { get; set; }
+    public override string Type { get; } = nameof(CustomItem);
+}

--- a/src/IIIF/IIIF.Tests/Serialisation/CustomClassSerializationTests.cs
+++ b/src/IIIF/IIIF.Tests/Serialisation/CustomClassSerializationTests.cs
@@ -42,7 +42,8 @@ public class CustomClassSerializationTests
                     {
                         "child"
                     }}
-                }
+                },
+                CustomField = "some-custom-field"
             },
             new CustomItem()
             {
@@ -53,7 +54,8 @@ public class CustomClassSerializationTests
                     {
                         "child"
                     }}
-                }
+                },
+                CustomField = "some-custom-field"
             }
         },
         PartOf = new List<ResourceBase>
@@ -137,12 +139,13 @@ public static class CustomSerializerX
 
 public class CustomCollectionItem : Collection
 {
-    public string CustomField = "custom";
+    public string CustomField { get; set; } = "custom";
 }
 
 public class CustomItem : StructureBase, ICollectionItem
 {
-    public string CustomField = "custom";
+    public string CustomField { get; set; } = "custom";
+    
     public List<IService> Services { get; set; }
     public override string Type { get; } = nameof(CustomItem);
 }

--- a/src/IIIF/IIIF/Serialisation/Deserialisation/CollectionItemConverter.cs
+++ b/src/IIIF/IIIF/Serialisation/Deserialisation/CollectionItemConverter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using IIIF.Presentation.V3;
 using Newtonsoft.Json.Linq;
 
@@ -11,12 +12,25 @@ public class CollectionItemConverter : ReadOnlyConverter<ICollectionItem>
     {
         var jsonObject = JObject.Load(reader);
 
-        ICollectionItem collectionItem = jsonObject["type"].Value<string>() switch
+        var type = jsonObject["type"].Value<string>();
+        ICollectionItem collectionItem = null;
+            
+        // Look for consumer-provided mapping
+        if (serializer.Context.Context is IDictionary<string, Func<JObject, ICollectionItem>> customMappings
+            && customMappings.TryGetValue(type, out var customMapping))
         {
-            nameof(Collection) => new Collection(),
-            nameof(Manifest) => new Manifest(),
-            _ => null
-        };
+            collectionItem = customMapping(jsonObject);
+        }
+
+        if (collectionItem == null)
+        {
+            collectionItem = type switch
+            {
+                nameof(Collection) => new Collection(),
+                nameof(Manifest) => new Manifest(),
+                _ => null
+            };
+        }
 
         serializer.Populate(jsonObject.CreateReader(), collectionItem);
         return collectionItem;

--- a/src/IIIF/IIIF/Serialisation/Deserialisation/CollectionItemConverter.cs
+++ b/src/IIIF/IIIF/Serialisation/Deserialisation/CollectionItemConverter.cs
@@ -16,10 +16,15 @@ public class CollectionItemConverter : ReadOnlyConverter<ICollectionItem>
         ICollectionItem collectionItem = null;
             
         // Look for consumer-provided mapping
-        if (serializer.Context.Context is IDictionary<string, Func<JObject, ICollectionItem>> customMappings
-            && customMappings.TryGetValue(type, out var customMapping))
+        if (serializer.Context.Context is IDictionary<Type, IDictionary<string, Func<JObject, object>>> ctx)
         {
-            collectionItem = customMapping(jsonObject);
+            if (ctx.TryGetValue(typeof(ICollectionItem), out var customMappings))
+            {
+                if (customMappings.TryGetValue(type, out var customMapping))
+                {
+                    collectionItem = (ICollectionItem) customMapping(jsonObject);
+                }
+            }
         }
 
         if (collectionItem == null)


### PR DESCRIPTION
This PR adds the ability for custom collection items to be created as well as a test to verify this behavior with both inheritance and interfaces.  The tests include custom serialization code as seen on the iiif-presentation library in order to mimic behavior there.

Relates to https://github.com/dlcs/iiif-presentation/issues/147 and https://github.com/dlcs/iiif-presentation/pull/151
