### PR TITLE
Add imageRequest.TryParse

### DIFF
--- a/src/IIIF/IIIF.Tests/ImageApi/ImageRequestXTests.cs
+++ b/src/IIIF/IIIF.Tests/ImageApi/ImageRequestXTests.cs
@@ -380,6 +380,7 @@ public class ImageRequestXTests
         // Assert
         success.Should().BeTrue();
         result.Should().BeEquivalentTo(expected);
+        result.ToString().Should().Be(input);
     }
     
     [Fact]

--- a/src/IIIF/IIIF.Tests/ImageApi/ImageRequestXTests.cs
+++ b/src/IIIF/IIIF.Tests/ImageApi/ImageRequestXTests.cs
@@ -356,6 +356,84 @@ public class ImageRequestXTests
         result.Should().BeEquivalentTo(expected);
         result.ToString().Should().Be(input);
     }
+    
+    [Fact]
+    public void Parse_ValidRequest_IncludingHostname()
+    {
+        const string input = "http://iiif.io/images/my-asset/0,0,512,1024/!500,250/!180/bitonal.png";
+        var expected = new ImageRequest
+        {
+            Region = new RegionParameter { X = 0, Y = 0, W = 512, H = 1024 },
+            Format = "png",
+            Size = new SizeParameter { Confined = true, Width = 500, Height = 250 },
+            Quality = "bitonal",
+            Rotation = new RotationParameter { Angle = 180f, Mirror = true },
+            OriginalPath = "my-asset/0,0,512,1024/!500,250/!180/bitonal.png",
+            Prefix = "images/",
+            Identifier = "my-asset",
+            Scheme = "http",
+            Server = "iiif.io",
+        };
+        
+        var success = ImageRequest.TryParse(input, out var result);
+        
+        // Assert
+        success.Should().BeTrue();
+        result.Should().BeEquivalentTo(expected);
+    }
+    
+    [Fact]
+    public void Parse_ValidRequest_IncludingHostname_NoPrefix()
+    {
+        const string input = "http://iiif.io/my-asset/0,0,512,1024/!500,250/!180/bitonal.png";
+        var expected = new ImageRequest
+        {
+            Region = new RegionParameter { X = 0, Y = 0, W = 512, H = 1024 },
+            Format = "png",
+            Size = new SizeParameter { Confined = true, Width = 500, Height = 250 },
+            Quality = "bitonal",
+            Rotation = new RotationParameter { Angle = 180f, Mirror = true },
+            OriginalPath = "my-asset/0,0,512,1024/!500,250/!180/bitonal.png",
+            Identifier = "my-asset",
+            Scheme = "http",
+            Server = "iiif.io",
+        };
+        
+        var success = ImageRequest.TryParse(input, out var result);
+        
+        // Assert
+        success.Should().BeTrue();
+        result.Should().BeEquivalentTo(expected);
+    }
+
+    [Theory]
+    [InlineData("default.jpg")]
+    [InlineData("/no-int/default.jpg")]
+    [InlineData("/circle/0/default.jpg")]
+    [InlineData("/portrait/max/0/default.jpg")]
+    [InlineData("http://hello.io/full/max/0/default.jpg")]
+    public void TryParse_InvalidRequest_ReturnsFalse(string input)
+    {
+        var success = ImageRequest.TryParse(input, out var result);
+
+        success.Should().BeFalse();
+        result.Should().BeNull();
+    }
+    
+    [Theory]
+    [MemberData(nameof(ImageRequests))]
+    public void TryParse_ValidRequest_CanRoundTripToString(string input, ImageRequest expected)
+    {
+        expected.Prefix = "iiif-img/27/1/";
+        expected.Identifier = "my-asset";
+        
+        var success = ImageRequest.TryParse(input, out var result);
+        
+        // Assert
+        success.Should().BeTrue();
+        result.Should().BeEquivalentTo(expected);
+        result.ToString().Should().Be(input);
+    }
 
     [Fact]
     public void ToString_ReflectsUpdates()

--- a/src/IIIF/IIIF/ImageApi/ImageRequest.cs
+++ b/src/IIIF/IIIF/ImageApi/ImageRequest.cs
@@ -187,6 +187,10 @@ public class ImageRequest
         var basePath = $"{Prefix}{Identifier}";
         if (IsBase) return basePath;
         if (IsInformationRequest) return $"{basePath}/info.json";
+        if (!string.IsNullOrEmpty(Scheme) && !string.IsNullOrEmpty(Server))
+        {
+            basePath = $"{Scheme}://{Server}/{basePath}";
+        }
             
         return $"{basePath}/{Region}/{Size}/{Rotation}/{Quality}.{Format}";
     }

--- a/src/IIIF/IIIF/ImageApi/ImageRequest.cs
+++ b/src/IIIF/IIIF/ImageApi/ImageRequest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace IIIF.ImageApi;
@@ -93,7 +94,7 @@ public class ImageRequest
     /// <param name="path">The image request path</param>
     /// <param name="imageRequest"></param>
     /// <returns>true if able to parse path to <see cref="ImageRequest"/>, else false</returns>
-    public static bool TryParse(string path, out ImageRequest? imageRequest)
+    public static bool TryParse(string path, [NotNullWhen(true)] out ImageRequest? imageRequest)
     {
         try
         {


### PR DESCRIPTION
Add `ImageRequest.TryParse()` to help with parsing of incoming requests.

I suspect there are more efficient ways to do this but the method signature won't need to change so we will be able to change implementation as required.