### PR TITLE
Refactor common deser logic to `ResourceDeserialiser`

### DIFF
--- a/src/IIIF/IIIF.Tests/Serialisation/Deserialisation/ResourceConverterTests.cs
+++ b/src/IIIF/IIIF.Tests/Serialisation/Deserialisation/ResourceConverterTests.cs
@@ -1,0 +1,149 @@
+﻿using System;
+using IIIF.Auth.V1;
+using IIIF.Auth.V2;
+using IIIF.ImageApi.V2;
+using IIIF.ImageApi.V3;
+using IIIF.Presentation.V3.Content;
+using IIIF.Presentation.V3.Extensions.NavPlace;
+using IIIF.Search.V1;
+using IIIF.Serialisation;
+using IIIF.Serialisation.Deserialisation;
+using Newtonsoft.Json;
+
+namespace IIIF.Tests.Serialisation.Deserialisation;
+
+public class ResourceConverterTests
+{
+    private readonly ResourceConverter sut = new();
+
+    [Theory]
+    [InlineData("SearchService1", typeof(SearchService))]
+    [InlineData("AuthLogoutService1", typeof(AuthLogoutService))]
+    [InlineData("AuthTokenService1", typeof(AuthTokenService))]
+    [InlineData("AutoCompleteService1", typeof(AutoCompleteService))]
+    public void ReadJson_IdentifiesType_FromAtType(string atType, Type expectedType)
+    {
+        var input = $"{{ \"@type\": \"{atType}\", \"@id\": \"{Guid.NewGuid()}\"}}";
+
+        JsonConvert.DeserializeObject<IResource>(input, sut)
+            .Should().BeOfType(expectedType, "Concrete type identified from @type");
+    }
+    
+    [Theory]
+    [InlineData("iiif:Image", typeof(ImageService2))]
+    [InlineData("ImageService2", typeof(ImageService2))]
+    public void ReadJson_IdentifiesImageService2_FromAtType(string atType, Type expectedType)
+    {
+        var input = $"{{ \"@type\": \"{atType}\", \"@id\": \"{Guid.NewGuid()}\"}}";
+
+        JsonConvert.DeserializeObject<IResource>(input, sut)
+            .Should().BeOfType(expectedType, "Concrete type identified from @type");
+    }
+    
+    [Theory]
+    [InlineData("iiif:Image")]
+    [InlineData("ImageService2")]
+    public void ReadJson_ImageService2_WorksWithExpandedProfile(string type)
+    {
+        var jsonId = @$"
+        {{
+           ""@context"": ""http://iiif.io/api/image/2/context.json"",
+           ""@id"": ""https://iiif-net/image.jpg"",
+           ""@type"": ""{type}"",
+           ""profile"": [
+               ""http://iiif.io/api/image/2/level2.json"",
+               {{
+                   ""formats"": [""tif""],
+                   ""qualities"": [""bitonal""],
+                   ""supports"": [""regionByPx""]
+               }}
+           ],
+           ""protocol"": ""http://iiif.io/api/image""
+       }}
+       ";
+        
+        var result = JsonConvert.DeserializeObject<IResource>(jsonId, sut, new ImageService2Converter());
+        
+        var imageService2 = result as ImageService2;
+        imageService2.Profile.Should().Be("http://iiif.io/api/image/2/level2.json");
+        imageService2.ProfileDescription.Formats.Should().Contain("tif");
+    }
+    
+    [Theory]
+    [InlineData("ImageService3", typeof(ImageService3))]
+    [InlineData("AuthAccessService2", typeof(AuthAccessService2))]
+    [InlineData("AuthAccessTokenError2", typeof(AuthAccessTokenError2))]
+    [InlineData("AuthAccessTokenService2", typeof(AuthAccessTokenService2))]
+    [InlineData("AuthLogoutService2", typeof(AuthLogoutService2))]
+    [InlineData("AuthProbeService2", typeof(AuthProbeService2))]
+    [InlineData("Sound", typeof(Sound))]
+    [InlineData("Video", typeof(Video))]
+    [InlineData("Image", typeof(Image))]
+    [InlineData("Feature", typeof(Feature))]
+    public void ReadJson_IdentifiesType_FromType(string type, Type expectedType)
+    {
+        var input = $"{{ \"type\": \"{type}\", \"id\": \"{Guid.NewGuid()}\"}}";
+
+        JsonConvert.DeserializeObject<IResource>(input, sut)
+            .Should().BeOfType(expectedType, "Concrete type identified from type");
+    }
+    
+    [Theory]
+    [InlineData("http://iiif.io/api/auth/0/logout", typeof(IIIF.Auth.V0.AuthLogoutService))]
+    [InlineData("http://iiif.io/api/auth/0/token", typeof(IIIF.Auth.V0.AuthTokenService))]
+    [InlineData("http://iiif.io/api/auth/0/login", typeof(IIIF.Auth.V0.AuthCookieService))]
+    [InlineData("http://iiif.io/api/auth/0/clickthrough", typeof(IIIF.Auth.V0.AuthCookieService))]
+    [InlineData("http://iiif.io/api/auth/0/kiosk", typeof(IIIF.Auth.V0.AuthCookieService))]
+    [InlineData("http://iiif.io/api/auth/0/external", typeof(IIIF.Auth.V0.AuthCookieService))]
+    [InlineData("http://iiif.io/api/auth/1/logout", typeof(AuthLogoutService))]
+    [InlineData("http://iiif.io/api/auth/1/token", typeof(AuthTokenService))]
+    [InlineData("http://iiif.io/api/auth/1/login", typeof(AuthCookieService))]
+    [InlineData("http://iiif.io/api/auth/1/clickthrough", typeof(AuthCookieService))]
+    [InlineData("http://iiif.io/api/auth/1/kiosk", typeof(AuthCookieService))]
+    [InlineData("http://iiif.io/api/auth/1/external", typeof(AuthCookieService))]
+    [InlineData("http://iiif.io/api/search/2/autocomplete", typeof(IIIF.Search.V2.AutoCompleteService))]
+    [InlineData("http://iiif.io/api/search/1/autocomplete", typeof(AutoCompleteService))]
+    [InlineData("http://iiif.io/api/search/2/search", typeof(IIIF.Search.V2.SearchService))]
+    public void ReadJson_IdentifiesType_FromProfile(string profile, Type expectedType)
+    {
+        var input = $"{{ \"profile\": \"{profile}\", \"id\": \"{Guid.NewGuid()}\"}}";
+
+        JsonConvert.DeserializeObject<IResource>(input, sut)
+            .Should().BeOfType(expectedType, "Concrete type identified from profile");
+    }
+
+    [Fact]
+    public void ReadJson_V2ServiceReference_IfAtTypeAndIdOnly()
+    {
+        var input = $"{{ \"@type\": \"ThisCanBeAnything\", \"@id\": \"{Guid.NewGuid()}\"}}";
+
+        JsonConvert.DeserializeObject<IResource>(input, sut)
+            .Should().BeOfType<V2ServiceReference>();
+    }
+    
+    [Fact]
+    public void ReadJson_V2ExternalService_IfAtType_AndUnableToDetermine()
+    {
+        var jsonId = "{\"@type\": \"Text\", \"@id\": \"https://service-reference-test\", \"label\": \"test\" }";
+        
+        var result = JsonConvert.DeserializeObject<IService>(jsonId, sut);
+        
+        result.Should().BeOfType<IIIF.Presentation.V2.ExternalService>();
+    }
+    
+    [Fact]
+    public void ReadJson_ExternalService()
+    {
+        var input =
+            "{\"id\": \"https://example.org/service/example\",\"type\": \"ExampleExtensionService\",\"profile\": \"https://example.org/docs/example-service.html\"}";
+        var expected = new IIIF.Presentation.V3.ExternalService("ExampleExtensionService")
+        {
+            Id = "https://example.org/service/example",
+            Profile = "https://example.org/docs/example-service.html",
+        };
+
+        var deserialised = JsonConvert.DeserializeObject<IResource>(input, sut);
+
+        deserialised.Should().BeEquivalentTo(expected);
+    }
+}

--- a/src/IIIF/IIIF.Tests/Serialisation/ServiceConverterTests.cs
+++ b/src/IIIF/IIIF.Tests/Serialisation/ServiceConverterTests.cs
@@ -48,29 +48,33 @@ public class ServiceConverterTests
         result.Should().BeOfType<ImageService2>(because);
     }
     
-    [Fact]
-    public void ReadJson_ImageService2_WorksWIthExpandedProfile()
+    [Theory]
+    [InlineData("ImageService2")]
+    [InlineData("iiif:Image")]
+    public void ReadJson_ImageService2_WorksWithExpandedProfile(string type)
     {
-        var jsonId = @"
-        {
+        var jsonId = @$"
+        {{
            ""@context"": ""http://iiif.io/api/image/2/context.json"",
            ""@id"": ""https://iiif-net/image.jpg"",
-           ""@type"": ""iiif:Image"",
+           ""@type"": ""{type}"",
            ""profile"": [
                ""http://iiif.io/api/image/2/level2.json"",
-               {
+               {{
                    ""formats"": [""tif""],
                    ""qualities"": [""bitonal""],
                    ""supports"": [""regionByPx""]
-               }
+               }}
            ],
            ""protocol"": ""http://iiif.io/api/image""
-       }
+       }}
        ";
         
-        var result = JsonConvert.DeserializeObject<ImageService2>(jsonId, sut, new ImageService2Converter());
-        result.Profile.Should().Be("http://iiif.io/api/image/2/level2.json");
-        result.ProfileDescription.Formats.Should().Contain("tif");
+        var result = JsonConvert.DeserializeObject<IService>(jsonId, sut, new ImageService2Converter());
+        
+        var imageService2 = result as ImageService2;
+        imageService2.Profile.Should().Be("http://iiif.io/api/image/2/level2.json");
+        imageService2.ProfileDescription.Formats.Should().Contain("tif");
     }
     
     [Theory]

--- a/src/IIIF/IIIF/Serialisation/Deserialisation/Helpers/ResourceDeserialiser.cs
+++ b/src/IIIF/IIIF/Serialisation/Deserialisation/Helpers/ResourceDeserialiser.cs
@@ -1,0 +1,141 @@
+﻿using System;
+using IIIF.Auth.V2;
+using IIIF.ImageApi.V2;
+using IIIF.ImageApi.V3;
+using Newtonsoft.Json.Linq;
+
+namespace IIIF.Serialisation.Deserialisation.Helpers;
+
+/// <summary>
+/// Common class for deserlialising <see cref="IResource"/> implementations
+/// </summary>
+/// <typeparam name="T">Type of resource to deserialise to</typeparam>
+internal class ResourceDeserialiser<T>
+    where T : class, IResource
+{
+    private readonly Func<string, T?>? additionalTypeBasedConverter;
+    private readonly Type callingConverterType;
+
+    /// <summary>
+    /// Instantiate new instance of <see cref="ResourceDeserialiser{T}"/>
+    /// </summary>
+    /// <param name="callingConverter">
+    /// <see cref="JsonConverter"/> making initial conversion, required as some instances may result in circular
+    /// dependency where initial converter is called repeatedly
+    /// </param>
+    /// <param name="additionalTypeBasedConverter">
+    /// Additional "type" based converters, required for types that inherit from <see cref="IResource"/>
+    /// </param>
+    public ResourceDeserialiser(JsonConverter callingConverter, Func<string, T?>? additionalTypeBasedConverter = null)
+    {
+        this.additionalTypeBasedConverter = additionalTypeBasedConverter;
+        callingConverterType =  callingConverter.GetType();
+    }
+    
+    public T? ReadJson(JsonReader reader, JsonSerializer serializer)
+    {
+        var jsonObject = JObject.Load(reader);
+        
+        var atTypeValue = jsonObject["@type"]?.Value<string>();
+
+        var result = ToObjectReturn(serializer, atTypeValue, jsonObject);
+        if (result != null) return result;
+
+        var service = IdentifyConcreteType(jsonObject, atTypeValue);
+
+        serializer.Populate(jsonObject.CreateReader(), service);
+        return service;
+    }
+    
+    /// <summary>
+    /// Used when a serialized class requires using ToObject to use custom converters
+    /// </summary>
+    private T? ToObjectReturn(JsonSerializer serializer, string? atTypeValue, JObject jsonObject)
+    {
+        // ImageService2 has a specific ImageService2Converter to handle "profile" prop, if type is ImageService2,
+        // copy serializers, minus current, to avoid 
+        if (atTypeValue is "iiif:Image" or nameof(ImageService2))
+        {
+            var copiedSerializer = serializer.CreateCopy(converter => converter.GetType() != callingConverterType);
+            var result = jsonObject.ToObject(typeof(ImageService2), copiedSerializer);
+            return result as T;
+        }
+
+        return null;
+    }
+
+    private T? IdentifyConcreteType(JObject jsonObject, string? atTypeValue)
+    {
+        T? service = null;
+        var typeValue = jsonObject["type"]?.Value<string>();
+        service = atTypeValue switch
+        {
+            "SearchService1" => new Search.V1.SearchService() as T,
+            "AuthLogoutService1" => new Auth.V1.AuthLogoutService() as T,
+            "AuthTokenService1" => new Auth.V1.AuthTokenService() as T,
+            "AutoCompleteService1" => new Search.V1.AutoCompleteService() as T,
+            _ => null,
+        };
+        if (service != null) return service;
+
+        if (!string.IsNullOrEmpty(typeValue))
+        {
+            service = typeValue switch
+            {
+                nameof(ImageService3) => new ImageService3() as T,
+                nameof(AuthAccessService2) => new AuthAccessService2() as T,
+                nameof(AuthAccessTokenError2) => new AuthAccessTokenError2() as T,
+                nameof(AuthAccessTokenService2) => new AuthAccessTokenService2() as T,
+                nameof(AuthLogoutService2) => new AuthLogoutService2() as T,
+                nameof(AuthProbeService2) => new AuthProbeService2() as T,
+                _ => null
+            };
+            if (service != null) return service;
+
+            service = additionalTypeBasedConverter?.Invoke(typeValue);
+            if (service != null) return service;
+        }
+
+        var profileToken = jsonObject["profile"];
+        if (profileToken != null)
+        {
+            var profile = profileToken.Value<string>();
+            service = profile switch
+            {
+                Auth.V1.AuthLogoutService.AuthLogout1Profile => new Auth.V1.AuthLogoutService() as T,
+                Auth.V1.AuthTokenService.AuthToken1Profile => new Auth.V1.AuthTokenService() as T,
+                Auth.V0.AuthLogoutService.AuthLogout0Profile => new Auth.V0.AuthLogoutService() as T,
+                Auth.V0.AuthTokenService.AuthToken0Profile => new Auth.V0.AuthTokenService() as T,
+                Search.V2.AutoCompleteService.AutoComplete2Profile => new Search.V2.AutoCompleteService() as T,
+                Search.V1.AutoCompleteService.AutoCompleteService1Profile => new Search.V1.AutoCompleteService() as T,
+                Search.V2.SearchService.Search2Profile => new Search.V2.SearchService() as T,
+                _ => null
+            };
+            if (service != null) return service;
+
+            const string auth0 = "http://iiif.io/api/auth/0/";
+            const string auth1 = "http://iiif.io/api/auth/1/";
+
+            if (profile.StartsWith(auth0)) return new Auth.V0.AuthCookieService(profile) as T;
+            if (profile.StartsWith(auth1)) return new Auth.V1.AuthCookieService(profile) as T;
+        }
+
+        // TODO handle ResourceBase items
+
+        if (!string.IsNullOrEmpty(atTypeValue))
+        {
+            // if there's @id and @type only, service reference
+            if (jsonObject.Count == 2 && jsonObject["@id"] != null)
+                return new V2ServiceReference() as T;
+            else
+                return new Presentation.V2.ExternalService() as T;
+        }
+
+        if (!string.IsNullOrEmpty(typeValue))
+        {
+            return new Presentation.V3.ExternalService(typeValue) as T;
+        }
+
+        return service;
+    }
+}

--- a/src/IIIF/IIIF/Serialisation/Deserialisation/ReadOnlyConverter.cs
+++ b/src/IIIF/IIIF/Serialisation/Deserialisation/ReadOnlyConverter.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using Newtonsoft.Json;
 
 namespace IIIF.Serialisation.Deserialisation;
 

--- a/src/IIIF/IIIF/Serialisation/Deserialisation/ResourceConverter.cs
+++ b/src/IIIF/IIIF/Serialisation/Deserialisation/ResourceConverter.cs
@@ -1,10 +1,7 @@
 ﻿using System;
-using IIIF.Auth.V2;
-using IIIF.ImageApi.V2;
-using IIIF.ImageApi.V3;
 using IIIF.Presentation.V3.Content;
 using IIIF.Presentation.V3.Extensions.NavPlace;
-using Newtonsoft.Json.Linq;
+using IIIF.Serialisation.Deserialisation.Helpers;
 
 namespace IIIF.Serialisation.Deserialisation;
 
@@ -16,79 +13,14 @@ public class ResourceConverter : ReadOnlyConverter<IResource>
     public override IResource? ReadJson(JsonReader reader, Type objectType, IResource? existingValue,
         bool hasExistingValue, JsonSerializer serializer)
     {
-        var jsonObject = JObject.Load(reader);
-
-        var service = IdentifyConcreteType(jsonObject);
-
-        serializer.Populate(jsonObject.CreateReader(), service);
-        return service;
-    }
-
-    private static IResource? IdentifyConcreteType(JObject jsonObject)
-    {
-        IResource? service = null;
-        var atType = jsonObject["@type"];
-        if (atType != null)
-            service = atType.Value<string>() switch
-            {
-                "SearchService1" => new Search.V1.SearchService(),
-                "AuthLogoutService1" => new Auth.V1.AuthLogoutService(),
-                "AuthTokenService1" => new Auth.V1.AuthTokenService(),
-                "AutoCompleteService1" => new Search.V1.AutoCompleteService(),
-                nameof(ImageService2) => new ImageService2(),
-                _ => null
-            };
-
-        if (service == null)
+        var converter = new ResourceDeserialiser<IResource>(this, type => type switch
         {
-            var type = jsonObject["type"];
-            if (type != null)
-                service = type.Value<string>() switch
-                {
-                    nameof(ImageService3) => new ImageService3(),
-                    nameof(AuthAccessService2) => new AuthAccessService2(),
-                    nameof(AuthAccessTokenError2) => new AuthAccessTokenError2(),
-                    nameof(AuthAccessTokenService2) => new AuthAccessTokenService2(),
-                    nameof(AuthLogoutService2) => new AuthLogoutService2(),
-                    nameof(AuthProbeService2) => new AuthProbeService2(),
-                    nameof(Sound) => new Sound(),
-                    nameof(Video) => new Video(),
-                    nameof(Image) => new Image(),
-                    nameof(Feature) => new Feature(),
-                    _ => null
-                };
-        }
-
-        if (service == null)
-        {
-            var profile = jsonObject["profile"].Value<string>();
-            service = profile switch
-            {
-                Auth.V1.AuthLogoutService.AuthLogout1Profile => new Auth.V1.AuthLogoutService(),
-                Auth.V1.AuthTokenService.AuthToken1Profile => new Auth.V1.AuthTokenService(),
-                Auth.V0.AuthLogoutService.AuthLogout0Profile => new Auth.V0.AuthLogoutService(),
-                Auth.V0.AuthTokenService.AuthToken0Profile => new Auth.V0.AuthTokenService(),
-                Search.V2.AutoCompleteService.AutoComplete2Profile => new Search.V2.AutoCompleteService(),
-                Search.V1.AutoCompleteService.AutoCompleteService1Profile => new Search.V1.AutoCompleteService(),
-                Search.V2.SearchService.Search2Profile => new Search.V2.SearchService(),
-                _ => null
-            };
-
-            if (service == null)
-            {
-                const string auth0 = "http://iiif.io/api/auth/0/";
-                const string auth1 = "http://iiif.io/api/auth/1/";
-
-                if (profile.StartsWith(auth0))
-                    service = new Auth.V0.AuthCookieService(profile);
-                else if (profile.StartsWith(auth1)) service = new Auth.V1.AuthCookieService(profile);
-            }
-        }
-
-        // TODO handle ResourceBase items
-
-        if (service == null) service = new V2ServiceReference();
-
-        return service;
+            nameof(Sound) => new Sound(),
+            nameof(Video) => new Video(),
+            nameof(Image) => new Image(),
+            nameof(Feature) => new Feature(),
+            _ => null
+        });
+        return converter.ReadJson(reader, serializer);
     }
 }

--- a/src/IIIF/IIIF/Serialisation/Deserialisation/ServiceConverter.cs
+++ b/src/IIIF/IIIF/Serialisation/Deserialisation/ServiceConverter.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using IIIF.Auth.V2;
-using IIIF.ImageApi.V2;
-using IIIF.ImageApi.V3;
-using Newtonsoft.Json.Linq;
+using IIIF.Serialisation.Deserialisation.Helpers;
 
 namespace IIIF.Serialisation.Deserialisation;
 
@@ -14,102 +11,7 @@ public class ServiceConverter : ReadOnlyConverter<IService>
     public override IService? ReadJson(JsonReader reader, Type objectType, IService? existingValue,
         bool hasExistingValue, JsonSerializer serializer)
     {
-        var jsonObject = JObject.Load(reader);
-        
-        var atType = jsonObject["@type"];
-        var typeValue = atType?.Value<string>();
-
-        var result = ToObjectReturn(serializer, typeValue, jsonObject);
-        if (result != null) return result;
-
-        var service = IdentifyConcreteType(jsonObject, typeValue);
-
-        serializer.Populate(jsonObject.CreateReader(), service);
-        return service;
-    }
-
-    /// <summary>
-    /// Used when a serialized class requires using ToObject to use custom converters
-    /// </summary>
-    /// <returns>either null, or an <see cref="IService"/> result</returns>
-    private IService? ToObjectReturn(JsonSerializer serializer, string? atTypeValue, JObject jsonObject)
-    {
-        if (atTypeValue is "iiif:Image" or nameof(ImageService2))
-        {
-            var copiedSerializer = serializer.CreateCopy(converter => converter is not ServiceConverter);
-            var result = jsonObject.ToObject(typeof(ImageService2), copiedSerializer);
-            return result as IService;
-        }
-
-        return null;
-    }
-
-    private static IService? IdentifyConcreteType(JObject jsonObject, string? atTypeValue)
-    {
-        IService? service = null;
-        var type = jsonObject["type"];
-        service = atTypeValue switch
-        {
-            "SearchService1" => new Search.V1.SearchService(),
-            "AuthLogoutService1" => new Auth.V1.AuthLogoutService(),
-            "AuthTokenService1" => new Auth.V1.AuthTokenService(),
-            "AutoCompleteService1" => new Search.V1.AutoCompleteService(),
-            _ => null,
-        };
-        if (service != null) return service;
-
-        if (type != null)
-            service = type.Value<string>() switch
-            {
-                nameof(ImageService3) => new ImageService3(),
-                nameof(AuthAccessService2) => new AuthAccessService2(),
-                nameof(AuthAccessTokenService2) => new AuthAccessTokenService2(),
-                nameof(AuthLogoutService2) => new AuthLogoutService2(),
-                nameof(AuthProbeService2) => new AuthProbeService2(),
-                _ => null
-            };
-        if (service != null) return service;
-
-        var profileToken = jsonObject["profile"];
-        if (profileToken != null)
-        {
-            var profile = profileToken.Value<string>();
-            service = profile switch
-            {
-                Auth.V1.AuthLogoutService.AuthLogout1Profile => new Auth.V1.AuthLogoutService(),
-                Auth.V1.AuthTokenService.AuthToken1Profile => new Auth.V1.AuthTokenService(),
-                Auth.V0.AuthLogoutService.AuthLogout0Profile => new Auth.V0.AuthLogoutService(),
-                Auth.V0.AuthTokenService.AuthToken0Profile => new Auth.V0.AuthTokenService(),
-                Search.V2.AutoCompleteService.AutoComplete2Profile => new Search.V2.AutoCompleteService(),
-                Search.V1.AutoCompleteService.AutoCompleteService1Profile => new Search.V1.AutoCompleteService(),
-                Search.V2.SearchService.Search2Profile => new Search.V2.SearchService(),
-                _ => null
-            };
-            if (service != null) return service;
-
-            const string auth0 = "http://iiif.io/api/auth/0/";
-            const string auth1 = "http://iiif.io/api/auth/1/";
-
-            if (profile.StartsWith(auth0)) return new Auth.V0.AuthCookieService(profile);
-            if (profile.StartsWith(auth1)) return new Auth.V1.AuthCookieService(profile);
-        }
-
-        // TODO handle ResourceBase items
-
-        if (atTypeValue != null)
-        {
-            // if there's @id and @type only, service reference
-            if (jsonObject.Count == 2 && jsonObject["@id"] != null)
-                return new V2ServiceReference();
-            else
-                return new Presentation.V2.ExternalService();
-        }
-
-        if (type != null)
-        {
-            return new Presentation.V3.ExternalService(type.Value<string>());
-        }
-
-        return service;
+        var converter = new ResourceDeserialiser<IService>(this);
+        return converter.ReadJson(reader, serializer);
     }
 }


### PR DESCRIPTION
Fixes #69

Shared by `ResourceConverter` (for `IResource`) and `ServiceConverter` (for `IService`) as there is a lot of overlap. Source of bug was the latter converter didn't handle non-null `"profile"` value but this was already handled in `ServiceConverter` so made sense to bring together.

