### PR TITLE
Allow Target and ResourceBaseV3Converter to use the ResourceDeserialiser

### DIFF
--- a/src/IIIF/IIIF.Tests/Serialisation/Deserialisation/ResourceBaseV3ConverterTests.cs
+++ b/src/IIIF/IIIF.Tests/Serialisation/Deserialisation/ResourceBaseV3ConverterTests.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using IIIF.Presentation.V3;
+using IIIF.Presentation.V3.Annotation;
+using IIIF.Serialisation.Deserialisation;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Linq;
+
+namespace IIIF.Tests.Serialisation.Deserialisation;
+
+public class ResourceBaseV3ConverterTests
+{
+    private readonly ResourceBaseV3Converter sut = new();
+    
+    [Theory]
+    [InlineData("AnnotationCollection", typeof(AnnotationCollection))]
+    [InlineData("AnnotationPage", typeof(AnnotationPage))]
+    [InlineData("Agent", typeof(Agent))]
+    [InlineData("Annotation", typeof(Annotation))]
+    [InlineData("Collection", typeof(Collection))]
+    [InlineData("Manifest", typeof(Manifest))]
+    [InlineData("SpecificResource", typeof(SpecificResource))]
+    [InlineData("TextualBody", typeof(TextualBody))]
+    public void ReadJson_IdentifiesType_FromType(string type, Type expectedType)
+    {
+        var input = $"{{ \"type\": \"{type}\", \"id\": \"{Guid.NewGuid()}\", \"value\" : \"stuff\" }}";
+
+        JsonConvert.DeserializeObject<ResourceBase>(input, sut)
+            .Should().BeOfType(expectedType, "Concrete type identified from type");
+    }
+    
+    [Theory]
+    [InlineData("supplementing", typeof(SupplementingDocumentAnnotation))]
+    [InlineData("painting", typeof(PaintingAnnotation))]
+    [InlineData("classifying", typeof(TypeClassifyingAnnotation))]
+    [InlineData("general", typeof(GeneralAnnotation))]
+    public void ReadJson_IdentifiesType_FromMotivation(string type, Type expectedType)
+    {
+        var input = $"{{ \"motivation\": \"{type}\", \"id\": \"{Guid.NewGuid()}\" }}";
+
+        JsonConvert.DeserializeObject<ResourceBase>(input, sut)
+            .Should().BeOfType(expectedType, "Concrete type identified from motivation");
+    }
+    
+    [Fact]
+    public void ReadJson_IdentifiesType_FromId()
+    {
+        var input = $"{{ \"id\": \"{Guid.NewGuid()}\" }}";
+
+        JsonConvert.DeserializeObject<ResourceBase>(input, sut)
+            .Should().BeOfType(typeof(ClassifyingBody), "Concrete type identified from id");
+    }
+    
+    [Fact]
+    public void ReadJson_IdentifiesType_FromCustomType()
+    {
+        // Arrange
+        var context = new Dictionary<string, Func<JObject, IResource>>()
+        {
+            ["testCustom"] = input => new TestCustomClass()
+        };
+        
+        var input = $"{{ \"type\": \"testCustom\" }}";
+
+        JsonConvert.DeserializeObject<ResourceBase>(input, new JsonSerializerSettings()
+            {
+                Converters = { new ResourceBaseV3Converter() },
+                Context = new StreamingContext(StreamingContextStates.All, context)
+            })
+            .Should().BeOfType(typeof(TestCustomClass), "Concrete type identified from custom context");
+    }
+
+    private class TestCustomClass : ResourceBase
+    {
+        public override string Type { get; }
+    }
+}

--- a/src/IIIF/IIIF.Tests/Serialisation/ManifestSerialisationTests.cs
+++ b/src/IIIF/IIIF.Tests/Serialisation/ManifestSerialisationTests.cs
@@ -347,4 +347,51 @@ public class ManifestSerialisationTests
         services.Should().HaveCount(1);
         services.Single().Should().BeEquivalentTo(expectedService);
     }
+    
+    [Fact]
+    public void CanDeserialise_AnnotationTargetingAnotherAnnotation()
+    {
+        // Stripped back manifest from https://github.com/digirati-co-uk/iiif-net/issues/74
+        var annotationTargetingAnother = @"
+{
+    ""@context"": ""http://iiif.io/api/presentation/3/context.json"",
+    ""id"": ""https://example.org/m3folwy0u7-mckceiru"",
+    ""type"": ""Manifest"",
+    ""items"": [
+        {
+            ""id"": ""https://example.org/m3folwy0u7-mckceiru/canvas/0sx2a5hbr6ga-mckcfbo6"",
+            ""type"": ""Canvas"",
+            ""annotations"": [
+                {
+                    ""id"": ""https://example.org/m3folwy0u7-mckceiru/canvas/0sx2a5hbr6ga-mckcfbo6/annotations/dsat3mfvzni-mckcffwo"",
+                    ""type"": ""AnnotationPage"",
+                    ""items"": [
+                        {
+                            ""id"": ""https://example.org/m3folwy0u7-mckceiru/canvas/0sx2a5hbr6ga-mckcfbo6/annotations/dsat3mfvzni-mckcffwo/annotation/aqibmu1dtrr-mckcfvrh"",
+                            ""type"": ""Annotation"",
+                            ""motivation"": ""describing"",
+                            ""target"": {
+                                ""id"": ""https://example.org/m3folwy0u7-mckceiru/annotation/qel8952t5f-mckcfbo5"",
+                                ""type"": ""Annotation""
+                            },
+                            ""body"": []
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}
+";
+
+        var mani = annotationTargetingAnother.FromJson<Manifest>();
+        
+        var expectedTarget = new Annotation
+        {
+            Id = "https://example.org/m3folwy0u7-mckceiru/annotation/qel8952t5f-mckcfbo5"
+        };
+
+        var target = mani.Items[0].Annotations[0].Items[0].As<Annotation>().Target;
+        target.Should().BeEquivalentTo(expectedTarget);
+    }
 }

--- a/src/IIIF/IIIF.Tests/Serialisation/ServiceConverterTests.cs
+++ b/src/IIIF/IIIF.Tests/Serialisation/ServiceConverterTests.cs
@@ -1,7 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using IIIF.ImageApi.V2;
 using IIIF.ImageApi.V3;
+using IIIF.Presentation.V3;
 using IIIF.Serialisation;
 using IIIF.Serialisation.Deserialisation;
 using Newtonsoft.Json;
@@ -134,6 +134,20 @@ public class ServiceConverterTests
         var result = JsonConvert.DeserializeObject<IService>(jsonId, sut);
         
         result.Should().BeOfType(expected);
+    }
+    
+    [Theory]
+    [InlineData("Sound")]
+    [InlineData("Image")]
+    [InlineData("Video")]
+    [InlineData("Feature")]
+    public void ReadJson_GetNullBack_WhenDeserializeResourceAsService(string type)
+    {
+        var jsonId = $"{{\"type\": \"{type}\"}}";
+        
+        var result = JsonConvert.DeserializeObject<IService>(jsonId, sut);
+        
+        result.Should().BeOfType<ExternalService>();
     }
 
     [Fact]

--- a/src/IIIF/IIIF.Tests/Serialisation/TargetConverterTests.cs
+++ b/src/IIIF/IIIF.Tests/Serialisation/TargetConverterTests.cs
@@ -67,7 +67,7 @@ public class TargetConverterTests
         var serialised = JsonConvert.SerializeObject(canvas, Formatting.None, sut);
 
         // Act
-        var deserialised = JsonConvert.DeserializeObject<IStructuralLocation>(serialised, sut);
+        var deserialised = JsonConvert.DeserializeObject<ResourceBase>(serialised, sut);
 
         // Assert
         deserialised.Should().BeEquivalentTo(canvas);

--- a/src/IIIF/IIIF/Presentation/V3/Annotation/Annotation.cs
+++ b/src/IIIF/IIIF/Presentation/V3/Annotation/Annotation.cs
@@ -21,5 +21,5 @@ public class Annotation : ResourceBase, IAnnotation
     /// </summary>
     [JsonProperty(Order = 900)]
     [JsonConverter(typeof(TargetConverter))]
-    public IStructuralLocation? Target { get; set; }
+    public ResourceBase? Target { get; set; }
 }

--- a/src/IIIF/IIIF/Serialisation/Deserialisation/Helpers/ResourceDeserialiser.cs
+++ b/src/IIIF/IIIF/Serialisation/Deserialisation/Helpers/ResourceDeserialiser.cs
@@ -1,7 +1,12 @@
 ﻿using System;
+using System.Collections.Generic;
 using IIIF.Auth.V2;
 using IIIF.ImageApi.V2;
 using IIIF.ImageApi.V3;
+using IIIF.Presentation.V3;
+using IIIF.Presentation.V3.Annotation;
+using IIIF.Presentation.V3.Content;
+using IIIF.Presentation.V3.Extensions.NavPlace;
 using Newtonsoft.Json.Linq;
 
 namespace IIIF.Serialisation.Deserialisation.Helpers;
@@ -13,7 +18,6 @@ namespace IIIF.Serialisation.Deserialisation.Helpers;
 internal class ResourceDeserialiser<T>
     where T : class, IResource
 {
-    private readonly Func<string, T?>? additionalTypeBasedConverter;
     private readonly Type callingConverterType;
 
     /// <summary>
@@ -23,12 +27,8 @@ internal class ResourceDeserialiser<T>
     /// <see cref="JsonConverter"/> making initial conversion, required as some instances may result in circular
     /// dependency where initial converter is called repeatedly
     /// </param>
-    /// <param name="additionalTypeBasedConverter">
-    /// Additional "type" based converters, required for types that inherit from <see cref="IResource"/>
-    /// </param>
-    public ResourceDeserialiser(JsonConverter callingConverter, Func<string, T?>? additionalTypeBasedConverter = null)
+    public ResourceDeserialiser(JsonConverter callingConverter)
     {
-        this.additionalTypeBasedConverter = additionalTypeBasedConverter;
         callingConverterType =  callingConverter.GetType();
     }
     
@@ -41,7 +41,7 @@ internal class ResourceDeserialiser<T>
         var result = ToObjectReturn(serializer, atTypeValue, jsonObject);
         if (result != null) return result;
 
-        var service = IdentifyConcreteType(jsonObject, atTypeValue);
+        var service = IdentifyConcreteType(jsonObject, serializer, atTypeValue);
 
         serializer.Populate(jsonObject.CreateReader(), service);
         return service;
@@ -64,7 +64,7 @@ internal class ResourceDeserialiser<T>
         return null;
     }
 
-    private T? IdentifyConcreteType(JObject jsonObject, string? atTypeValue)
+    private T? IdentifyConcreteType(JObject jsonObject, JsonSerializer serializer, string? atTypeValue)
     {
         T? service = null;
         var typeValue = jsonObject["type"]?.Value<string>();
@@ -88,11 +88,31 @@ internal class ResourceDeserialiser<T>
                 nameof(AuthAccessTokenService2) => new AuthAccessTokenService2() as T,
                 nameof(AuthLogoutService2) => new AuthLogoutService2() as T,
                 nameof(AuthProbeService2) => new AuthProbeService2() as T,
+                nameof(AnnotationCollection) => new AnnotationCollection() as T,
+                nameof(AnnotationPage) => new AnnotationPage() as T,
+                nameof(Agent) => new Agent() as T,
+                nameof(Annotation) => new Annotation() as T,
+                nameof(Sound) => new Sound() as T,
+                nameof(Video) => new Video() as T,
+                nameof(Image) => new Image() as T,
+                nameof(Feature) => new Feature() as T,
+                nameof(Canvas) => new Canvas() as T,
+                nameof(Collection) => new Collection() as T,
+                nameof(Manifest) => new Manifest() as T,
+                nameof(SpecificResource) => new SpecificResource() as T,
+                nameof(TextualBody) => new TextualBody(jsonObject["value"].Value<string>()) as T,
                 _ => null
             };
+            
             if (service != null) return service;
-
-            service = additionalTypeBasedConverter?.Invoke(typeValue);
+        }
+        
+        // Look for consumer-provided mapping
+        if (typeValue != null
+            && serializer.Context.Context is IDictionary<string, Func<JObject, IResource>> customMappings
+            && customMappings.TryGetValue(typeValue, out var customMapping))
+        {
+            service = customMapping(jsonObject) as T;
             if (service != null) return service;
         }
 
@@ -119,6 +139,20 @@ internal class ResourceDeserialiser<T>
             if (profile.StartsWith(auth0)) return new Auth.V0.AuthCookieService(profile) as T;
             if (profile.StartsWith(auth1)) return new Auth.V1.AuthCookieService(profile) as T;
         }
+        
+        if (jsonObject.ContainsKey("motivation"))
+        {
+            var motivation = jsonObject["motivation"]?.Value<string>();
+            service = motivation switch
+            {
+                Presentation.V3.Constants.Motivation.Supplementing => new SupplementingDocumentAnnotation() as T,
+                Presentation.V3.Constants.Motivation.Painting => new PaintingAnnotation() as T,
+                Presentation.V3.Constants.Motivation.Classifying => new TypeClassifyingAnnotation() as T,
+                _ => new GeneralAnnotation(motivation) as T
+            };
+            
+            if (service != null) return service;
+        }
 
         if (!string.IsNullOrEmpty(atTypeValue))
         {
@@ -132,6 +166,11 @@ internal class ResourceDeserialiser<T>
         if (!string.IsNullOrEmpty(typeValue))
         {
             return new Presentation.V3.ExternalService(typeValue) as T;
+        }
+        
+        if (jsonObject.ContainsKey("id"))
+        {
+            return new ClassifyingBody(jsonObject["id"].Value<string>()) as T;
         }
 
         return service;

--- a/src/IIIF/IIIF/Serialisation/Deserialisation/ResourceBaseV3Converter.cs
+++ b/src/IIIF/IIIF/Serialisation/Deserialisation/ResourceBaseV3Converter.cs
@@ -5,6 +5,7 @@ using IIIF.ImageApi.V3;
 using IIIF.Presentation.V3;
 using IIIF.Presentation.V3.Annotation;
 using IIIF.Presentation.V3.Content;
+using IIIF.Serialisation.Deserialisation.Helpers;
 using Newtonsoft.Json.Linq;
 
 namespace IIIF.Serialisation.Deserialisation;
@@ -19,67 +20,7 @@ public class ResourceBaseV3Converter : ReadOnlyConverter<ResourceBase>
         bool hasExistingValue,
         JsonSerializer serializer)
     {
-        var jsonObject = JObject.Load(reader);
-
-        var resourceBase = IdentifyConcreteType(jsonObject, serializer);
-
-        serializer.Populate(jsonObject.CreateReader(), resourceBase);
-        return resourceBase;
-    }
-
-    private static ResourceBase? IdentifyConcreteType(JObject jsonObject, JsonSerializer serializer)
-    {
-        ResourceBase? resourceBase = null;
-        if (!jsonObject.ContainsKey("type"))
-        {
-            resourceBase = new ClassifyingBody(jsonObject["id"].Value<string>());
-            return resourceBase;
-        }
-
-        var type = jsonObject["type"].Value<string>();
-        resourceBase = type switch
-        {
-            nameof(ImageService3) => new ImageService3(),
-            nameof(Agent) => new Agent(),
-            nameof(Annotation) => new Annotation(),
-            nameof(AnnotationCollection) => new AnnotationCollection(),
-            nameof(AnnotationPage) => new AnnotationPage(),
-            nameof(Sound) => new Sound(),
-            nameof(Canvas) => new Canvas(),
-            nameof(Collection) => new Collection(),
-            nameof(Image) => new Image(),
-            nameof(Manifest) => new Manifest(),
-            nameof(SpecificResource) => new SpecificResource(),
-            nameof(AuthProbeService2) => new AuthProbeService2(),
-            nameof(AuthAccessTokenError2) => new AuthAccessTokenError2(),
-            nameof(TextualBody) => new TextualBody(jsonObject["value"].Value<string>()),
-            _ => null
-        };
-        
-        if (resourceBase != null) return resourceBase;
-
-        if (jsonObject.ContainsKey("motivation"))
-        {
-            var motivation = jsonObject["motivation"]?.Value<string>();
-            resourceBase = motivation switch
-            {
-                Presentation.V3.Constants.Motivation.Supplementing => new SupplementingDocumentAnnotation(),
-                Presentation.V3.Constants.Motivation.Painting => new PaintingAnnotation(),
-                Presentation.V3.Constants.Motivation.Classifying => new TypeClassifyingAnnotation(),
-                _ => new GeneralAnnotation(motivation)
-            };
-        }
-        
-        // Look for consumer-provided mapping
-        if (type != null
-            && serializer.Context.Context is IDictionary<string, Func<JObject, ResourceBase>> customMappings
-            && customMappings.TryGetValue(type, out var customMapping))
-        {
-            resourceBase = customMapping(jsonObject);
-        }
-
-        if (resourceBase == null) return new ExternalResource(type);
-
-        return resourceBase;
+        var converter = new ResourceDeserialiser<ResourceBase>(this);
+        return converter.ReadJson(reader, serializer);
     }
 }

--- a/src/IIIF/IIIF/Serialisation/Deserialisation/ResourceConverter.cs
+++ b/src/IIIF/IIIF/Serialisation/Deserialisation/ResourceConverter.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using IIIF.Presentation.V3.Content;
-using IIIF.Presentation.V3.Extensions.NavPlace;
 using IIIF.Serialisation.Deserialisation.Helpers;
 
 namespace IIIF.Serialisation.Deserialisation;
@@ -13,14 +11,7 @@ public class ResourceConverter : ReadOnlyConverter<IResource>
     public override IResource? ReadJson(JsonReader reader, Type objectType, IResource? existingValue,
         bool hasExistingValue, JsonSerializer serializer)
     {
-        var converter = new ResourceDeserialiser<IResource>(this, type => type switch
-        {
-            nameof(Sound) => new Sound(),
-            nameof(Video) => new Video(),
-            nameof(Image) => new Image(),
-            nameof(Feature) => new Feature(),
-            _ => null
-        });
+        var converter = new ResourceDeserialiser<IResource>(this);
         return converter.ReadJson(reader, serializer);
     }
 }


### PR DESCRIPTION
Resolves #74 

This PR allows `Target` to be used in a broader context.  It does this by refactoring the `ResourceBaseV3Converter` to use the `ResourceDeserialiser` and then modifies `TargetConverter` to use it