### PR TITLE
SanitiseHtml() retains content of replaced tags

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -118,14 +118,15 @@ Manifest deserialisedManifest = streamContainingManifest.FromJsonStream<Manifest
 `HtmlSanitiser` contains a `SanitiseHtml()` extension method on `string` to help sanitise HTML.
 
 ```cs
-string original = "<p>my markup<div>invalid</div><p>";
-string safe = original.SanitiseHtml();
+string original = "<div><p>my markup</p><ul><li>invalid</li><li>invalid2</li></ul></div>";
+Console.WriteLine(original.SanitiseHtml());
+// output: "<span><p>my markup</p>invalid invalid2</span>"
 ```
 
 See [IIIF Presentation 3.0 docs](https://iiif.io/api/presentation/3.0/#45-html-markup-in-property-values) for details on html markup.
 
-> Note: The rules around markup differs between Presentation 2.1 and 3.0. This method uses 3.0 which permits a couple of tags not mentioned in 2.1 (`small`, `sub` and `sup`).
->
+> [!NOTE]
+>  The rules around markup differs between Presentation 2.1 and 3.0. This method uses 3.0 which permits a couple of tags not mentioned in 2.1 (`small`, `sub` and `sup`).
 
 #### Manifest Traversal
 

--- a/src/IIIF/IIIF.Tests/Presentation/HtmlSanitiserTests.cs
+++ b/src/IIIF/IIIF.Tests/Presentation/HtmlSanitiserTests.cs
@@ -60,6 +60,16 @@ public class HtmlSanitiserTests
     }
 
     [Fact]
+    public void SanitiseHtml_DoesNotAddSpaceForInlineElements()
+    {
+        const string input = "<strong>some</strong>thing<em>here</em><div>another</div><div>thing</div>";
+        const string expected = "<span>somethinghere another thing</span>";
+        var actual = input.SanitiseHtml();
+
+        actual.Should().Be(expected);
+    }
+
+    [Fact]
     public void SanitiseHtml_WillReplaceTagReplacementValue_WithSpace()
     {
         // This test highlights a quirk to be aware of: "~||~" is internal space identifier so will be lost

--- a/src/IIIF/IIIF.Tests/Presentation/HtmlSanitiserTests.cs
+++ b/src/IIIF/IIIF.Tests/Presentation/HtmlSanitiserTests.cs
@@ -17,7 +17,7 @@ public class HtmlSanitiserTests
     public void SanitiseHtml_ReturnsEmptyString_IfGivenInvalidHtml(bool ignoreNonHtml)
     {
         const string input = "<div>invalid html</div>";
-        const string expected = "";
+        const string expected = "<span>invalid html</span>";
 
         var actual = input.SanitiseHtml(ignoreNonHtml);
 
@@ -47,16 +47,28 @@ public class HtmlSanitiserTests
     }
 
     [Fact]
-    public void SanitiseHtml_RemovesInvalidTags_IncludingChildElements()
+    public void SanitiseHtml_RemovesInvalidTags_RetainingChildElements()
     {
         const string input =
             "<br><span><small><i>hi</i></small></span><div><p>child paragraph</p></div><h1>Test</h1><ul><ol><li>foo</li></ol></ul><p><script>alert('hi');</script><sub>valid</sub> <sup>paragraph</sup></p>";
-        const string expected = "<br><span><small><i>hi</i></small></span><p><sub>valid</sub> <sup>paragraph</sup></p>";
+        const string expected =
+            "<br><span><small><i>hi</i></small></span><p>child paragraph</p>Test foo<p>alert('hi');<sub>valid</sub> <sup>paragraph</sup></p>";
 
         var actual = input.SanitiseHtml();
 
         actual.Should().Be(expected);
     }
+
+    [Fact]
+    public void SanitiseHtml_WillReplaceTagReplacementValue_WithSpace()
+    {
+        // This test highlights a quirk to be aware of: "~||~" is internal space identifier so will be lost
+        const string input = "<p>This is the replacement for a tag: ~||~. It will be lost here</p>";
+        const string expected = "<p>This is the replacement for a tag:  . It will be lost here</p>";
+
+        var actual = input.SanitiseHtml();
+        actual.Should().Be(expected);
+    } 
 
     [Theory]
     [InlineData("http://localhost")]

--- a/src/IIIF/IIIF/Presentation/HtmlSanitiser.cs
+++ b/src/IIIF/IIIF/Presentation/HtmlSanitiser.cs
@@ -33,6 +33,14 @@ public static class HtmlSanitiser
             ["img"] = new HashSet<string> { "src", "alt" },
         };
 
+    // These are inline elements and should not have a space added
+    // from https://www.w3.org/TR/2011/WD-html5-20110405/text-level-semantics.html
+    private static readonly HashSet<string> InlineElements = new()
+    {
+        "a", "em", "strong", "small", "s", "cite", "q", "dfn", "abbr", "time", "code", "var", "samp", "kbd", "sub", "i",
+        "b", "mark", "ruby", "rt", "rp", "bdi", "bdo", "span", "br", "wbr"
+    };
+
     static HtmlSanitiser()
     {
         // NOTE - used HTML sanitiser lib doesn't allow tag-specific attributes, so subscribe to RemovingAttribute
@@ -58,11 +66,15 @@ public static class HtmlSanitiser
                  * This custom handling (after further handling from caller) => "One Two Three Four"
                  */
                 var childNodes = args.Tag.ChildNodes;
-                if (childNodes.Length == 1 && childNodes[0].NodeType == NodeType.Text)
+                if (childNodes.Length == 1 &&
+                    childNodes[0].NodeType == NodeType.Text &&
+                    !InlineElements.Contains(args.Tag.TagName.ToLower()))
                 {
+                    // If the child is text and current element is block-level, append placeholder to become space 
                     childNodes[0].TextContent = $"{TagReplacement}{childNodes[0].TextContent}{TagReplacement}";
                 }
-                args.Tag.Replace(args.Tag.ChildNodes.ToArray());
+
+                args.Tag.Replace(childNodes.ToArray());
             }
             else
             {

--- a/src/IIIF/IIIF/Presentation/HtmlSanitiser.cs
+++ b/src/IIIF/IIIF/Presentation/HtmlSanitiser.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
+using AngleSharp.Dom;
 using Ganss.Xss;
 
 namespace IIIF.Presentation;
@@ -10,14 +12,18 @@ namespace IIIF.Presentation;
 /// <remarks>See https://iiif.io/api/presentation/3.0/#45-html-markup-in-property-values</remarks>
 public static class HtmlSanitiser
 {
+    // Placeholder that is used to represent removed child tags, replaced with space later.
+    // Intentionally not a space to retain any spaces included in source string
+    private const string TagReplacement = "~||~";
+    
     private static readonly HtmlSanitizerOptions HtmlSanitizerOptions = new()
     {
         AllowedTags = new HashSet<string> { "a", "b", "br", "i", "img", "p", "small", "span", "sub", "sup" },
         AllowedAttributes = new HashSet<string>(0),
         AllowedSchemes = new HashSet<string> { "http", "https", "mailto" },
-        UriAttributes = new HashSet<string> { "href" }
+        UriAttributes = new HashSet<string> { "href" },
     };
-    
+
     private static readonly HtmlSanitizer Sanitizer = new(HtmlSanitizerOptions);
     
     private static readonly Dictionary<string, ISet<string>> ValidAttributesPerTag
@@ -29,21 +35,45 @@ public static class HtmlSanitiser
 
     static HtmlSanitiser()
     {
-        // NOTE - used HTML sanitiser lib doesn't allow tag-specific attributes so subscribe to RemovingAttribute
+        // NOTE - used HTML sanitiser lib doesn't allow tag-specific attributes, so subscribe to RemovingAttribute
         // events and cancel those that should be allowed
-        Sanitizer.RemovingAttribute += (sender, args) =>
+        Sanitizer.RemovingAttribute += (_, args) =>
         {
             // Attribute can also be removed if scheme isn't allowed 
             if (args.Reason != RemoveReason.NotAllowedAttribute) return;
             args.Cancel = ValidAttributesPerTag.TryGetValue(args.Tag.TagName.ToLower(), out var allowedAttributes)
                           && allowedAttributes.Contains(args.Attribute.Name.ToLower());
         };
+        Sanitizer.RemovingTag += (_, args) =>
+        {
+            if (args.Tag.HasChildNodes)
+            {
+                /*
+                 * This mimics native KeepChildNodes=true handling but that just removes tags, which can result in
+                 * content being "grouped". This similar handling adds a temporary placeholder either side
+                 * of replaced text nodes, these are then replaced with spaces later (see Sanitise()).
+                 * 
+                 * e.g. for "<ul><li>One</li><li>Two</li><li>Three Four</li><ul>"
+                 * Native KeepChildNodes => "OneTwoThree Four"
+                 * This custom handling (after further handling from caller) => "One Two Three Four"
+                 */
+                var childNodes = args.Tag.ChildNodes;
+                if (childNodes.Length == 1 && childNodes[0].NodeType == NodeType.Text)
+                {
+                    childNodes[0].TextContent = $"{TagReplacement}{childNodes[0].TextContent}{TagReplacement}";
+                }
+                args.Tag.Replace(args.Tag.ChildNodes.ToArray());
+            }
+            else
+            {
+                args.Tag.Remove();
+            }
+        };
     }
-    
-    
+
     /// <summary>
     /// Sanitise markup to meet requirements in IIIF spec. This will
-    ///
+    /// 
     ///  * Remove all tags except: a, b, br, i, img, p, small, span, sub and sup
     ///  * Remove all attributes other than href on the a tag, src and alt on the img tag
     ///  * Remove all href attributes that start with the strings other than “http:”, “https:”, and “mailto:”
@@ -51,7 +81,7 @@ public static class HtmlSanitiser
     ///  * XML comments
     ///  * Processing instructions
     ///  * Strip whitespace from either side of HTML string
-    ///
+    /// 
     /// see https://iiif.io/api/presentation/3.0/#45-html-markup-in-property-values
     /// </summary>
     /// <param name="propertyValue">Value to be sanitised</param>
@@ -64,16 +94,18 @@ public static class HtmlSanitiser
     /// <see cref="ignoreNonHtml"/> is true
     /// </param>
     /// <returns>Sanitised markup value</returns>
+    /// <remarks>
+    /// To maintain appropriate spacing when replacing internal tags the string "~||~" is used as a temporary
+    /// placeholder. If this string legitimately appears in the string it will be replaced.
+    /// </remarks>
     public static string SanitiseHtml(this string propertyValue, bool ignoreNonHtml = true,
-        string nonHtmlWrappingTag = "span") 
+        string nonHtmlWrappingTag = "span")
     {
-        if (string.IsNullOrEmpty(propertyValue)) return propertyValue;
-        if (ignoreNonHtml && !IsHtmlString(propertyValue)) return propertyValue;
+        if (string.IsNullOrEmpty(propertyValue) || ignoreNonHtml && !IsHtmlString(propertyValue)) return propertyValue;
 
-        var workingString = Sanitizer.Sanitize(propertyValue.Trim());
+        var workingString = Sanitise(propertyValue.Trim());
 
-        if (string.IsNullOrEmpty(workingString)) return workingString;
-        if (IsHtmlString(workingString)) return workingString;
+        if (string.IsNullOrEmpty(workingString) || IsHtmlString(workingString)) return workingString;
         
         if (!HtmlSanitizerOptions.AllowedTags.Contains(nonHtmlWrappingTag))
         {
@@ -83,7 +115,25 @@ public static class HtmlSanitiser
         }
         workingString = $"<{nonHtmlWrappingTag}>{workingString}</{nonHtmlWrappingTag}>";
 
-        return Sanitizer.Sanitize(workingString);
+        return Sanitise(workingString);
+    }
+
+    /// <summary>
+    /// Sanitise provided text, removing any invalid tags/attributes etc
+    /// </summary>
+    private static string Sanitise(string toSanitise)
+    {
+        var workingString = Sanitizer.Sanitize(toSanitise);
+        
+        // At this point "<span><ul><li>One</li><li>Two</li><li>Three Four</li><ul></span>" would
+        // be "<span>~||~One~||~~||~Two~||~~||~Three Four~||~</span>", clean that up to
+        // "<span>One Two Three Four</span>"
+        return workingString
+            .Replace($"{TagReplacement}<", "<")
+            .Replace($">{TagReplacement}", ">")
+            .Replace($"{TagReplacement}{TagReplacement}", TagReplacement)
+            .Replace(TagReplacement, " ")
+            .Trim();
     }
 
     private static bool IsHtmlString(string candidate) 


### PR DESCRIPTION
The `SanitiseHtml()` method was removing invalid tags and their content. This change updates to removing the invalid tags only but maintains the text content.

Internally we're using [HtmlSanitizer](https://github.com/mganss/HtmlSanitizer) to handle removing invalid content. This has a [`KeepChildTags`](https://github.com/mganss/HtmlSanitizer/issues/75#issuecomment-1132967680) bool value that does this but it means that content can be squashed. E.g. `"<ul><li>One</li><li>Two</li><li>Three Four</li><ul>"` would become `"OneTwoThree Four"` but we want `"One Two Three Four"`. 

To achieve this I'm using a temporary replacement value of `~||~` which is then replaced with strings. This feels clunky but I couldn't think of a cleaner way to do it as the approach is to recursively handle each tag in turn, rather than the string as a whole so it's difficult to do the replacement in 1 pass (happy to change if there are better options!).

Resolves #48 