### PR TITLE
Set JsonProperty for Audio + Video

### DIFF
--- a/src/IIIF/IIIF.Tests/Presentation/V3/Content/SoundTests.cs
+++ b/src/IIIF/IIIF.Tests/Presentation/V3/Content/SoundTests.cs
@@ -1,0 +1,21 @@
+﻿using IIIF.Presentation.V3.Content;
+using IIIF.Serialisation;
+
+namespace IIIF.Tests.Presentation.V3.Content;
+
+public class SoundTests
+{
+    [Fact]
+    public void Sound_SerialiseOrder()
+    {
+        var sound = new Sound { Duration = 500.3, Id = "https://example.org/sound" };
+        var expected = @"{
+  ""id"": ""https://example.org/sound"",
+  ""type"": ""Sound"",
+  ""duration"": 500.3
+}";
+        var actual = sound.AsJson();
+        
+        actual.ShouldMatchJson(expected);
+    }
+}

--- a/src/IIIF/IIIF.Tests/Presentation/V3/Content/VideoTests.cs
+++ b/src/IIIF/IIIF.Tests/Presentation/V3/Content/VideoTests.cs
@@ -1,0 +1,23 @@
+﻿using IIIF.Presentation.V3.Content;
+using IIIF.Serialisation;
+
+namespace IIIF.Tests.Presentation.V3.Content;
+
+public class VideoTests
+{
+    [Fact]
+    public void Video_SerialiseOrder()
+    {
+        var sound = new Video { Duration = 500.3, Id = "https://example.org/video", Width = 200, Height = 300 };
+        var expected = @"{
+  ""id"": ""https://example.org/video"",
+  ""type"": ""Video"",
+  ""width"": 200,
+  ""height"": 300,
+  ""duration"": 500.3
+}";
+        var actual = sound.AsJson();
+        
+        actual.ShouldMatchJson(expected);
+    }
+}

--- a/src/IIIF/IIIF.Tests/StringAssertionX.cs
+++ b/src/IIIF/IIIF.Tests/StringAssertionX.cs
@@ -1,6 +1,4 @@
-﻿using FluentAssertions;
-
-namespace IIIF.Tests;
+﻿namespace IIIF.Tests;
 
 public static class StringAssertionX
 {

--- a/src/IIIF/IIIF/Presentation/V3/Content/Sound.cs
+++ b/src/IIIF/IIIF/Presentation/V3/Content/Sound.cs
@@ -4,7 +4,7 @@ namespace IIIF.Presentation.V3.Content;
 
 public class Sound : ExternalResource, ITemporal, IPaintable
 {
-    public double? Duration { get; set; }
+    [JsonProperty(Order = 11)] public double? Duration { get; set; }
 
     public Sound() : base(nameof(Sound))
     {

--- a/src/IIIF/IIIF/Presentation/V3/Content/Video.cs
+++ b/src/IIIF/IIIF/Presentation/V3/Content/Video.cs
@@ -4,9 +4,9 @@ namespace IIIF.Presentation.V3.Content;
 
 public class Video : ExternalResource, ISpatial, ITemporal, IPaintable
 {
-    public int? Width { get; set; }
-    public int? Height { get; set; }
-    public double? Duration { get; set; }
+    [JsonProperty(Order = 11)] public int? Width { get; set; }
+    [JsonProperty(Order = 12)] public int? Height { get; set; }
+    [JsonProperty(Order = 13)] public double? Duration { get; set; }
 
     public Video() : base(nameof(Video))
     {


### PR DESCRIPTION
Ensures dimensions come after `"id"` and `"type"` for consistent serialisation.