### PR TITLE
Add region calculation

### DIFF
--- a/src/IIIF/IIIF.Tests/ImageApi/ImageRequestXTests.cs
+++ b/src/IIIF/IIIF.Tests/ImageApi/ImageRequestXTests.cs
@@ -257,7 +257,7 @@ public class ImageRequestXTests
         var action = () => ImageRequest.Parse($"{prefix}my-asset/info.jsonll", prefix);
         
         // Assert
-        action.Should().ThrowExactly<ArgumentException>();
+        action.Should().Throw<ArgumentException>();
     }
 
     [Theory]

--- a/src/IIIF/IIIF.Tests/ImageApi/RegionParameterTests.cs
+++ b/src/IIIF/IIIF.Tests/ImageApi/RegionParameterTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using IIIF.Exceptions;
 using IIIF.ImageApi;
 
 namespace IIIF.Tests.ImageApi;
@@ -81,5 +82,89 @@ public class RegionParameterTests
     {
         Action act = () => RegionParameter.Parse(input);
         act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void GetExtractedRegionSize_ReturnsImageDimensions_IfFull()
+    {
+        var regionParameter = new RegionParameter { Full = true };
+        var imageSize = new Size(100, 200);
+        
+        var result = regionParameter.GetExtractedRegionSize(imageSize);
+        
+        result.Should().Be(imageSize);
+    }
+
+    [Theory]
+    [InlineData(100, 200)]
+    [InlineData(200, 100)]
+    public void GetExtractedRegionSize_ReturnsShorterDimension_IfSquare(int w, int h)
+    {
+        var regionParameter = new RegionParameter { Square = true };
+        var imageSize = new Size(w, h);
+        
+        var result = regionParameter.GetExtractedRegionSize(imageSize);
+        
+        result.Width.Should().Be(result.Height).And.Be(Math.Min(w, h));
+    }
+
+    [Theory]
+    [InlineData("0,0,128,199", 128, 199, "Start at top left")]
+    [InlineData("125,15,120,140", 120, 140, "Start within image, size does not exceed")]
+    [InlineData("125,15,200,200", 175, 185, "Image cropped as outside dimension")]
+    public void GetExtractedRegionSize_Correct_XYWH(string xywh, int w, int h, string reason)
+    {
+        var regionParameter = RegionParameter.Parse(xywh);
+        var imageSize = new Size(300, 200);
+        
+        var result = regionParameter.GetExtractedRegionSize(imageSize);
+        
+        result.Width.Should().Be(w, reason);
+        result.Height.Should().Be(h, reason);
+    }
+    
+    [Theory]
+    [InlineData("pct:0,0,25,50", 75, 100, "Start at top left")]
+    [InlineData("pct:41.6,7.5,40,70", 120, 140, "Start within image, size does not exceed")]
+    [InlineData("pct:41.6,7.5,66.6,100", 175, 185, "Image cropped as outside dimension")]
+    public void GetExtractedRegionSize_Correct_Pct(string xywh, int w, int h, string reason)
+    {
+        var regionParameter = RegionParameter.Parse(xywh);
+        var imageSize = new Size(300, 200);
+        
+        var result = regionParameter.GetExtractedRegionSize(imageSize);
+        
+        result.Width.Should().Be(w, reason);
+        result.Height.Should().Be(h, reason);
+    }
+
+    [Theory]
+    [InlineData("301,0,25,25")]
+    [InlineData("0,201,25,25")]
+    [InlineData("301,201,25,25")]
+    [InlineData("pct:101,0,25,25")]
+    [InlineData("pct:0,101,25,25")]
+    [InlineData("pct:101,101,25,25")]
+    public void GetExtractedRegionSize_Throws_IfRegionOutsideBounds(string region)
+    {
+        var regionParameter = RegionParameter.Parse(region);
+        var imageSize = new Size(300, 200);
+        
+        Action act = () => regionParameter.GetExtractedRegionSize(imageSize);
+        act.Should().ThrowExactly<RegionException>().WithMessage("Region is outside image bounds");
+    }
+    
+    [Theory]
+    [InlineData("0,0,0,25")]
+    [InlineData("0,0,25,0")]
+    [InlineData("pct:0,0,0,25")]
+    [InlineData("pct:0,0,25,0")]
+    public void GetExtractedRegionSize_Throws_IfRegionWithOrHeight0(string region)
+    {
+        var regionParameter = RegionParameter.Parse(region);
+        var imageSize = new Size(300, 200);
+        
+        Action act = () => regionParameter.GetExtractedRegionSize(imageSize);
+        act.Should().ThrowExactly<RegionException>().WithMessage("Region * cannot be zero");
     }
 }

--- a/src/IIIF/IIIF.Tests/ImageApi/RegionParameterTests.cs
+++ b/src/IIIF/IIIF.Tests/ImageApi/RegionParameterTests.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using IIIF.ImageApi;
+
+namespace IIIF.Tests.ImageApi;
+
+public class RegionParameterTests
+{
+    [Fact]
+    public void Parse_Correct_Full()
+    {
+        const string full = "full";
+        var expected = new RegionParameter
+        {
+            Full = true
+        };
+
+        // Act
+        var rotationParameter = RegionParameter.Parse(full);
+
+        // Assert
+        rotationParameter.Should().BeEquivalentTo(expected);
+        rotationParameter.ToString().Should().Be(full);
+    }
+    
+    [Fact]
+    public void Parse_Correct_Square()
+    {
+        const string square = "square";
+        var expected = new RegionParameter
+        {
+            Square = true
+        };
+
+        // Act
+        var rotationParameter = RegionParameter.Parse(square);
+
+        // Assert
+        rotationParameter.Should().BeEquivalentTo(expected);
+        rotationParameter.ToString().Should().Be(square);
+    }
+    
+    [Fact]
+    public void Parse_Correct_XYWH()
+    {
+        const string xywh = "10,20,30,40";
+        var expected = new RegionParameter
+        {
+            X = 10, Y = 20, W = 30, H = 40
+        };
+
+        // Act
+        var rotationParameter = RegionParameter.Parse(xywh);
+
+        // Assert
+        rotationParameter.Should().BeEquivalentTo(expected);
+        rotationParameter.ToString().Should().Be(xywh);
+    }
+    
+    [Fact]
+    public void Parse_Correct_Percent()
+    {
+        const string percent = "pct:10.1,20,30,40";
+        var expected = new RegionParameter
+        {
+            Percent = true, X = 10.10F, Y = 20, W = 30, H = 40
+        };
+
+        // Act
+        var rotationParameter = RegionParameter.Parse(percent);
+
+        // Assert
+        rotationParameter.Should().BeEquivalentTo(expected);
+        rotationParameter.ToString().Should().Be(percent);
+    }
+
+    [Theory]
+    [InlineData("pct:10,20,30")]
+    [InlineData("all")]
+    [InlineData("foo,bar")]
+    public void Parse_Throws_IfUnableToParse(string input)
+    {
+        Action act = () => RegionParameter.Parse(input);
+        act.Should().Throw<ArgumentException>();
+    }
+}

--- a/src/IIIF/IIIF/Exceptions/RegionException.cs
+++ b/src/IIIF/IIIF/Exceptions/RegionException.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace IIIF.Exceptions;
+
+/// <summary>
+/// Exception thrown when a region is invalid.
+/// </summary>
+public class RegionException : ArgumentException
+{
+    public RegionException()
+    {
+    }
+
+    public RegionException(string message) : base(message)
+    {
+    }
+
+    public RegionException(string message, Exception inner) : base(message, inner)
+    {
+    }
+}

--- a/src/IIIF/IIIF/ImageApi/RegionParameter.cs
+++ b/src/IIIF/IIIF/ImageApi/RegionParameter.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Diagnostics;
+using IIIF.Exceptions;
+using IIIF.Utils;
 
 namespace IIIF.ImageApi;
 
@@ -55,8 +58,92 @@ public class RegionParameter
         }
         catch (Exception ex)
         {
-            throw new ArgumentException($"Expected 'full', 'square', 'pct:x,y,w,h' or 'x,y,w,h'. Found: {pathPart}",
+            throw new RegionException($"Expected 'full', 'square', 'pct:x,y,w,h' or 'x,y,w,h'. Found: {pathPart}",
                 ex);
+        }
+    }
+    
+    /// <summary>
+    /// Calculate the extracted region size from the full image size. 
+    /// </summary>
+    /// <param name="imageSize"><see cref="Size"/> parameter for source image</param>
+    /// <returns>Extracted region <see cref="Size"/></returns>
+    /// <exception cref="RegionException">
+    /// Thrown if the requested region’s height or width is zero, or if the region is entirely outside the bounds of
+    /// the reported dimensions
+    /// </exception>
+    public Size GetExtractedRegionSize(Size imageSize)
+    {
+        var extractedSize = ExtractedRegionSizeInternal(imageSize);
+
+        ThrowIfZero(extractedSize.Width, "width");
+        ThrowIfZero(extractedSize.Height, "height");
+
+        return extractedSize;
+
+        static void ThrowIfZero(int value, string dimensionName)
+        {
+            if (value == 0) throw new RegionException($"Region {dimensionName} cannot be zero");
+        }
+    }
+
+    private Size ExtractedRegionSizeInternal(Size imageSize)
+    {
+        if (Full) return imageSize;
+        if (Square) return Size.Square(Math.Min(imageSize.Width, imageSize.Height));
+        
+        // Get x,y,w,h from absolute or percentage values
+        var location = GetRegionLocation(imageSize);
+        
+        // Ensure region is within image bounds
+        EnsureRegionValid(imageSize, location);
+
+        return new Size(location.W, location.H);
+    }
+
+    private static void EnsureRegionValid(Size imageSize, RegionLocation location)
+    {
+        if (location.X > imageSize.Width || location.Y > imageSize.Height)
+        {
+            throw new RegionException("Region is outside image bounds");
+        }
+        
+        // if the region extends beyond the dimensions of the full image, crop at image's edge
+        if (location.X + location.W > imageSize.Width)
+        {
+            location.W = imageSize.Width - location.X;
+        }
+
+        if (location.Y + location.H > imageSize.Height)
+        {
+            location.H = imageSize.Height - location.Y;
+        }
+    }
+
+    private RegionLocation GetRegionLocation(Size imageSize) =>
+        Percent
+            ? new RegionLocation(
+                X.PercentOf(imageSize.Width),
+                Y.PercentOf(imageSize.Height),
+                W.PercentOf(imageSize.Width),
+                H.PercentOf(imageSize.Height)
+            )
+            : new RegionLocation((int)X, (int)Y, (int)W, (int)H);
+
+    [DebuggerDisplay("{X},{Y},{W},{H}")]
+    private class RegionLocation
+    {
+        public int X { get; }
+        public int Y { get; }
+        public int W { get; set; }
+        public int H { get; set; }
+
+        public RegionLocation(int x, int y, int w, int h)
+        {
+            X = x;
+            Y = y;
+            W = w;
+            H = h;
         }
     }
 }

--- a/src/IIIF/IIIF/ImageApi/RegionParameter.cs
+++ b/src/IIIF/IIIF/ImageApi/RegionParameter.cs
@@ -8,6 +8,10 @@ namespace IIIF.ImageApi;
 /// <remarks>see https://iiif.io/api/image/3.0/#41-region </remarks>
 public class RegionParameter
 {
+    private const string FullRegion = "full";
+    private const string SquareRegion = "square";
+    private const string PercentPrefix = "pct:";
+
     [JsonProperty(Order = 91, PropertyName = "x")]
     public float X { get; set; }
 
@@ -24,11 +28,10 @@ public class RegionParameter
     public bool Square { get; set; }
     public bool Percent { get; set; }
 
-
     public override string ToString()
     {
-        if (Full) return "full";
-        if (Square) return "square";
+        if (Full) return FullRegion;
+        if (Square) return SquareRegion;
         var xywh = $"{X},{Y},{W},{H}";
         if (Percent) return $"pct:{xywh}";
         return xywh;
@@ -38,10 +41,10 @@ public class RegionParameter
     {
         try
         {
-            if (pathPart == "full") return new RegionParameter { Full = true };
-            if (pathPart == "square") return new RegionParameter { Square = true };
+            if (pathPart == FullRegion) return new RegionParameter { Full = true };
+            if (pathPart == SquareRegion) return new RegionParameter { Square = true };
 
-            var percent = pathPart.StartsWith("pct:");
+            var percent = pathPart.StartsWith(PercentPrefix);
             var stringParts = pathPart.Substring(percent ? 4 : 0).Split(',');
             var xywh = Array.ConvertAll(stringParts, float.Parse);
             return new RegionParameter
@@ -50,9 +53,10 @@ public class RegionParameter
                 Percent = percent
             };
         }
-        catch
+        catch (Exception ex)
         {
-            throw new ArgumentException("Expected 'full', 'square' or 'x,y,w,h'. Found " + pathPart);
+            throw new ArgumentException($"Expected 'full', 'square', 'pct:x,y,w,h' or 'x,y,w,h'. Found: {pathPart}",
+                ex);
         }
     }
 }

--- a/src/IIIF/IIIF/Size.cs
+++ b/src/IIIF/IIIF/Size.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using IIIF.Utils;
 
 namespace IIIF;
 
@@ -134,19 +135,15 @@ public class Size
             return Square(targetWidth ?? targetHeight ?? -1);
 
         return new Size(
-            targetWidth ?? size.Width * targetHeight!.Value / size.Height,
-            targetHeight ?? size.Height * targetWidth!.Value / size.Width);
+            targetWidth ?? ((size.Width * targetHeight!.Value) / size.Height),
+            targetHeight ?? ((size.Height * targetWidth!.Value) / size.Width));
     }
 
     /// <summary>
     /// Resize specified Size growing/shrinking by specified % value
     /// </summary>
-    public static Size ResizePercent(Size size, float percentage)
-    {
-        var width = Convert.ToInt32(size.Width * (percentage / 100));
-        var height = Convert.ToInt32(size.Height * (percentage / 100));
-        return new Size(width, height);
-    }
+    public static Size ResizePercent(Size size, float percentage) =>
+        new(percentage.PercentOf(size.Width), percentage.PercentOf(size.Height));
 
     /// <summary>
     /// Get % size difference between larger and smaller size, based on longest edge.

--- a/src/IIIF/IIIF/Utils/FloatX.cs
+++ b/src/IIIF/IIIF/Utils/FloatX.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace IIIF.Utils;
+
+public static class FloatX
+{
+    internal static int PercentOf(this float percentage, int value)
+        => Convert.ToInt32(value * (percentage / 100));
+}


### PR DESCRIPTION
Add `RegionParameter.GetExtractedRegionSize()`. This takes the original image size and will attempt to determine the extracted region according to https://iiif.io/api/image/3.0/#41-region.

Calculation will crop size as per

> If the request specifies a region which extends beyond the dimensions of the full image as reported in the image information document, then the service SHOULD return an image cropped at the image’s edge, rather than adding empty space.

and will throw a `RegionException` in event of: 

> If the requested region’s height or width is zero, or if the region is entirely outside the bounds of the reported dimensions, then the server SHOULD return a 400 (Bad Request) status code.

`RegionException` inherits from `ArgumentException` to avoid breaking consumers. `ArgumentException` was thrown if parsing was invalid.