### PR TITLE
Fix navPlace GeoJSON coordinate type errors

### DIFF
--- a/src/IIIF/IIIF.Tests/Serialisation/GeometrySerialisationTests.cs
+++ b/src/IIIF/IIIF.Tests/Serialisation/GeometrySerialisationTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using IIIF.Presentation.V3.Extensions.NavPlace;
 using IIIF.Serialisation.Deserialisation;
 using Newtonsoft.Json;
@@ -9,7 +9,7 @@ namespace IIIF.Tests.Serialisation;
 public class GeometrySerialisationTests
 {
     private readonly JsonSerializerSettings jsonSerializerSettings;
-    
+
     public GeometrySerialisationTests()
     {
         // NOTE: Using JsonSerializerSettings to facilitate testing as it makes it a LOT easier
@@ -20,7 +20,7 @@ public class GeometrySerialisationTests
             Converters = new List<JsonConverter> { new GeometryConverter() }
         };
     }
-    
+
     [Fact]
     public void Serialize_ConvertsPoint()
     {
@@ -34,7 +34,7 @@ public class GeometrySerialisationTests
         // Assert
         result.Should().Be(expected);
     }
-    
+
     [Fact]
     public void Deserialize_ConvertsPoint()
     {
@@ -48,13 +48,14 @@ public class GeometrySerialisationTests
         // Assert
         result.Should().BeEquivalentTo(expected);
     }
-    
+
     [Fact]
     public void Serialize_ConvertsMultipoint()
     {
         // Arrange
-        var geometry = new MultiPoint { Coordinates = new List<List<double>> { new(){100.0, 20.2, 10.1}} };
-        const string expected = "{\"type\":\"MultiPoint\",\"coordinates\":[[100.0,20.2,10.1]]}";
+        var geometry = new MultiPoint
+            { Coordinates = new List<List<double>> { new() { 100.0, 0.0 }, new() { 101.0, 1.0 } } };
+        const string expected = "{\"type\":\"MultiPoint\",\"coordinates\":[[100.0,0.0],[101.0,1.0]]}";
 
         // Act
         var result = JsonConvert.SerializeObject(geometry, jsonSerializerSettings);
@@ -62,13 +63,14 @@ public class GeometrySerialisationTests
         // Assert
         result.Should().Be(expected);
     }
-    
+
     [Fact]
     public void Deserialize_ConvertsMultiPoint()
     {
         // Arrange
-        const string multiPoint = "{\"type\":\"MultiPoint\",\"coordinates\":[[100.0,20.2,10.1]]}";
-        var expected = new MultiPoint { Coordinates = new List<List<double>> { new(){100.0, 20.2, 10.1}} };
+        const string multiPoint = "{\"type\":\"MultiPoint\",\"coordinates\":[[100.0,0.0],[101.0,1.0]]}";
+        var expected = new MultiPoint
+            { Coordinates = new List<List<double>> { new() { 100.0, 0.0 }, new() { 101.0, 1.0 } } };
 
         // Act
         var result = JsonConvert.DeserializeObject<MultiPoint>(multiPoint, jsonSerializerSettings);
@@ -76,13 +78,13 @@ public class GeometrySerialisationTests
         // Assert
         result.Should().BeEquivalentTo(expected);
     }
-    
+
     [Fact]
     public void Serialize_ConvertsLineString()
     {
-        // Arrange
-        var geometry = new LineString { Coordinates = new List<double> {100.0, 20.2, 10.1} };
-        const string expected = "{\"type\":\"LineString\",\"coordinates\":[100.0,20.2,10.1]}";
+        // Arrange - see https://datatracker.ietf.org/doc/html/rfc7946#appendix-A.2
+        var geometry = new LineString { Coordinates = new List<List<double>> { new(){100.0, 0.0}, new(){101.0, 1.0}} };
+        const string expected = "{\"type\":\"LineString\",\"coordinates\":[[100.0,0.0],[101.0,1.0]]}";
 
         // Act
         var result = JsonConvert.SerializeObject(geometry, jsonSerializerSettings);
@@ -90,13 +92,13 @@ public class GeometrySerialisationTests
         // Assert
         result.Should().Be(expected);
     }
-    
+
     [Fact]
     public void Deserialize_ConvertsLineString()
     {
-        // Arrange
-        const string lineString = "{\"type\":\"LineString\",\"coordinates\":[100.0,20.2,10.1]}";
-        var expected = new LineString { Coordinates = new List<double> {100.0, 20.2, 10.1} };
+        // Arrange - see https://datatracker.ietf.org/doc/html/rfc7946#appendix-A.2
+        const string lineString = "{\"type\":\"LineString\",\"coordinates\":[[100.0,0.0],[101.0,1.0]]}";
+        var expected = new LineString { Coordinates = new List<List<double>> { new(){100.0, 0.0}, new(){101.0, 1.0}} };
 
         // Act
         var result = JsonConvert.DeserializeObject<LineString>(lineString, jsonSerializerSettings);
@@ -104,13 +106,42 @@ public class GeometrySerialisationTests
         // Assert
         result.Should().BeEquivalentTo(expected);
     }
-    
+
+    [Fact]
+    public void Deserialize_ConvertsLineString_WithMultiplePositions()
+    {
+        // Arrange — the issue #91 failing case: coordinates[0] is a position array, not a double
+        const string lineString = "{\"type\":\"LineString\",\"coordinates\":[[100.0,0.0],[101.0,1.0],[102.0,2.0]]}";
+        var expected = new LineString
+        {
+            Coordinates = new List<List<double>>
+            {
+                new() {100.0, 0.0},
+                new() {101.0, 1.0},
+                new() {102.0, 2.0}
+            }
+        };
+
+        // Act
+        var result = JsonConvert.DeserializeObject<LineString>(lineString, jsonSerializerSettings);
+
+        // Assert
+        result.Should().BeEquivalentTo(expected);
+    }
+
     [Fact]
     public void Serialize_ConvertsMultiLineString()
     {
-        // Arrange
-        var geometry = new MultiLineString { Coordinates = new List<List<double>> { new () {100.0, 20.2, 10.1}}  };
-        const string expected = "{\"type\":\"MultiLineString\",\"coordinates\":[[100.0,20.2,10.1]]}";
+        // Arrange - https://datatracker.ietf.org/doc/html/rfc7946#appendix-A.5
+        var geometry = new MultiLineString
+        {
+            Coordinates = new List<List<List<double>>>
+            {
+                new() { new(){100.0, 0.0}, new(){101.0, 1.0} },
+                new() { new(){102.0, 2.0}, new(){103.0, 3.0} }
+            }
+        };
+        const string expected = "{\"type\":\"MultiLineString\",\"coordinates\":[[[100.0,0.0],[101.0,1.0]],[[102.0,2.0],[103.0,3.0]]]}";
 
         // Act
         var result = JsonConvert.SerializeObject(geometry, jsonSerializerSettings);
@@ -118,13 +149,20 @@ public class GeometrySerialisationTests
         // Assert
         result.Should().Be(expected);
     }
-    
+
     [Fact]
     public void Deserialize_ConvertsMultiLineString()
     {
-        // Arrange
-        const string multiLineString = "{\"type\":\"MultiLineString\",\"coordinates\":[[100.0,20.2,10.1]]}";
-        var expected = new MultiLineString { Coordinates = new List<List<double>> { new () {100.0, 20.2, 10.1}}  };
+        // Arrange - https://datatracker.ietf.org/doc/html/rfc7946#appendix-A.5
+        const string multiLineString = "{\"type\":\"MultiLineString\",\"coordinates\":[[[100.0,0.0],[101.0,1.0]],[[102.0,2.0],[103.0,3.0]]]}";
+        var expected = new MultiLineString
+        {
+            Coordinates = new List<List<List<double>>>
+            {
+                new() { new(){100.0, 0.0}, new(){101.0, 1.0} },
+                new() { new(){102.0, 2.0}, new(){103.0, 3.0} }
+            }
+        };
 
         // Act
         var result = JsonConvert.DeserializeObject<MultiLineString>(multiLineString, jsonSerializerSettings);
@@ -132,13 +170,24 @@ public class GeometrySerialisationTests
         // Assert
         result.Should().BeEquivalentTo(expected);
     }
-    
+
     [Fact]
     public void Serialize_ConvertsPolygon()
     {
-        // Arrange
-        var geometry = new Polygon { Coordinates = new List<List<double>> { new ()  {100.0, 20.2, 10.1}} };
-        const string expected = "{\"type\":\"Polygon\",\"coordinates\":[[100.0,20.2,10.1]]}";
+        // Arrange — exterior ring only (closed: first == last position)
+        // see https://datatracker.ietf.org/doc/html/rfc7946#appendix-A.3
+        var geometry = new Polygon
+        {
+            Coordinates = new List<List<List<double>>>
+            {
+                new()
+                {
+                    new() { 100.0, 0.0 }, new() { 101.0, 0.0 }, new() { 101.0, 1.0 }, new() { 100.0, 1.0 },
+                    new() { 100.0, 0.0 }
+                }
+            }
+        };
+        const string expected = "{\"type\":\"Polygon\",\"coordinates\":[[[100.0,0.0],[101.0,0.0],[101.0,1.0],[100.0,1.0],[100.0,0.0]]]}";
 
         // Act
         var result = JsonConvert.SerializeObject(geometry, jsonSerializerSettings);
@@ -146,13 +195,23 @@ public class GeometrySerialisationTests
         // Assert
         result.Should().Be(expected);
     }
-    
+
     [Fact]
     public void Deserialize_ConvertsPolygon()
     {
-        // Arrange
-        const string polygon = "{\"type\":\"Polygon\",\"coordinates\":[[100.0,20.2,10.1]]}";
-        var expected = new Polygon { Coordinates = new List<List<double>> { new ()  {100.0, 20.2, 10.1}} };
+        // Arrange - https://datatracker.ietf.org/doc/html/rfc7946#appendix-A.3
+        const string polygon = "{\"type\":\"Polygon\",\"coordinates\":[[[100.0,0.0],[101.0,0.0],[101.0,1.0],[100.0,1.0],[100.0,0.0]]]}";
+        var expected = new Polygon
+        {
+            Coordinates = new List<List<List<double>>>
+            {
+                new()
+                {
+                    new() { 100.0, 0.0 }, new() { 101.0, 0.0 }, new() { 101.0, 1.0 }, new() { 100.0, 1.0 },
+                    new() { 100.0, 0.0 }
+                }
+            }
+        };
 
         // Act
         var result = JsonConvert.DeserializeObject<Polygon>(polygon, jsonSerializerSettings);
@@ -160,23 +219,65 @@ public class GeometrySerialisationTests
         // Assert
         result.Should().BeEquivalentTo(expected);
     }
-    
+
     [Fact]
-    public void Serialize_ConvertsMultiPolygon()
+    public void Deserialize_ConvertsPolygon_WithHole()
     {
-        // Arrange
-        var geometry = new MultiPolygon
+        // Arrange — the issue #91 failing case: exterior ring + interior ring (hole)
+        // see https://datatracker.ietf.org/doc/html/rfc7946#appendix-A.3
+        const string polygon = "{\"type\":\"Polygon\",\"coordinates\":[[[100.0,0.0],[101.0,0.0],[101.0,1.0],[100.0,1.0],[100.0,0.0]],[[100.2,0.2],[100.2,0.8],[100.8,0.8],[100.8,0.2],[100.2,0.2]]]}";
+        var expected = new Polygon
         {
             Coordinates = new List<List<List<double>>>
             {
-                new ()
+                new()
                 {
-                    new List<double> { 100.0, 20.2, 10.1 }
+                    new() { 100.0, 0.0 }, new() { 101.0, 0.0 }, new() { 101.0, 1.0 }, new() { 100.0, 1.0 },
+                    new() { 100.0, 0.0 }
+                },
+                new()
+                {
+                    new() { 100.2, 0.2 }, new() { 100.2, 0.8 }, new() { 100.8, 0.8 }, new() { 100.8, 0.2 },
+                    new() { 100.2, 0.2 }
                 }
             }
         };
-        
-        const string expected = "{\"type\":\"MultiPolygon\",\"coordinates\":[[[100.0,20.2,10.1]]]}";
+
+        // Act
+        var result = JsonConvert.DeserializeObject<Polygon>(polygon, jsonSerializerSettings);
+
+        // Assert
+        result.Should().BeEquivalentTo(expected);
+    }
+
+    [Fact]
+    public void Serialize_ConvertsMultiPolygon()
+    {
+        // Arrange - https://datatracker.ietf.org/doc/html/rfc7946#appendix-A.3
+        var geometry = new MultiPolygon
+        {
+            Coordinates = new List<List<List<List<double>>>>
+            {
+                new()
+                {
+                    new()
+                    {
+                        new() { 102.0, 2.0 }, new() { 103.0, 2.0 }, new() { 103.0, 3.0 }, new() { 102.0, 3.0 },
+                        new() { 102.0, 2.0 }
+                    }
+                },
+                new()
+                {
+                    new()
+                    {
+                        new() { 100.0, 0.0 }, new() { 101.0, 0.0 }, new() { 101.0, 1.0 }, new() { 100.0, 1.0 },
+                        new() { 100.0, 0.0 }
+                    }
+                }
+            }
+        };
+
+        const string expected = "{\"type\":\"MultiPolygon\",\"coordinates\":[[[[102.0,2.0],[103.0,2.0],[103.0,3.0],[102.0,3.0],[102.0,2.0]]],[[[100.0,0.0],[101.0,0.0],[101.0,1.0],[100.0,1.0],[100.0,0.0]]]]}";
 
         // Act
         var result = JsonConvert.SerializeObject(geometry, jsonSerializerSettings);
@@ -184,19 +285,31 @@ public class GeometrySerialisationTests
         // Assert
         result.Should().Be(expected);
     }
-    
+
     [Fact]
     public void Deserialize_ConvertsMultiPolygon()
     {
-        // Arrange
-        const string multiPolygon = "{\"type\":\"MultiPolygon\",\"coordinates\":[[[100.0,20.2,10.1]]]}";
+        // Arrange - https://datatracker.ietf.org/doc/html/rfc7946#appendix-A.6
+        const string multiPolygon = "{\"type\":\"MultiPolygon\",\"coordinates\":[[[[102.0,2.0],[103.0,2.0],[103.0,3.0],[102.0,3.0],[102.0,2.0]]],[[[100.0,0.0],[101.0,0.0],[101.0,1.0],[100.0,1.0],[100.0,0.0]]]]}";
         var expected = new MultiPolygon
         {
-            Coordinates = new List<List<List<double>>>
+            Coordinates = new List<List<List<List<double>>>>
             {
-                new ()
+                new()
                 {
-                    new List<double> { 100.0, 20.2, 10.1 }
+                    new()
+                    {
+                        new() { 102.0, 2.0 }, new() { 103.0, 2.0 }, new() { 103.0, 3.0 }, new() { 102.0, 3.0 },
+                        new() { 102.0, 2.0 }
+                    }
+                },
+                new()
+                {
+                    new()
+                    {
+                        new() { 100.0, 0.0 }, new() { 101.0, 0.0 }, new() { 101.0, 1.0 }, new() { 100.0, 1.0 },
+                        new() { 100.0, 0.0 }
+                    }
                 }
             }
         };
@@ -207,22 +320,25 @@ public class GeometrySerialisationTests
         // Assert
         result.Should().BeEquivalentTo(expected);
     }
-    
+
     [Fact]
     public void Serialize_ConvertsGeometryCollection()
     {
-        // Arrange
+        // Arrange - https://datatracker.ietf.org/doc/html/rfc7946#appendix-A.6
         var geometry = new GeometryCollection
         {
             Geometries = new List<Geometry>
             {
                 new MultiPolygon
                 {
-                    Coordinates = new List<List<List<double>>>
+                    Coordinates = new List<List<List<List<double>>>>
                     {
-                        new ()
+                        new()
                         {
-                            new List<double> { 100.0, 20.2, 10.1 }
+                            new()
+                            {
+                                new() { 102.0, 2.0 }, new() { 103.0, 2.0 }, new() { 103.0, 3.0 }, new() { 102.0, 2.0 }
+                            }
                         }
                     }
                 },
@@ -232,8 +348,8 @@ public class GeometrySerialisationTests
                 }
             }
         };
-        
-        const string expected = "{\"type\":\"GeometryCollection\",\"geometries\":[{\"type\":\"MultiPolygon\",\"coordinates\":[[[100.0,20.2,10.1]]]},{\"type\":\"Point\",\"coordinates\":[100.0,20.2,10.1]}]}";
+
+        const string expected = "{\"type\":\"GeometryCollection\",\"geometries\":[{\"type\":\"MultiPolygon\",\"coordinates\":[[[[102.0,2.0],[103.0,2.0],[103.0,3.0],[102.0,2.0]]]]},{\"type\":\"Point\",\"coordinates\":[100.0,20.2,10.1]}]}";
 
         // Act
         var result = JsonConvert.SerializeObject(geometry, jsonSerializerSettings);
@@ -241,23 +357,23 @@ public class GeometrySerialisationTests
         // Assert
         result.Should().Be(expected);
     }
-    
+
     [Fact]
     public void Deserialize_ConvertsGeometryCollection()
     {
-        // Arrange
-        const string multiPolygon = "{\"type\":\"GeometryCollection\",\"geometries\":[{\"type\":\"MultiPolygon\",\"coordinates\":[[[100.0,20.2,10.1]]]},{\"type\":\"Point\",\"coordinates\":[100.0,20.2,10.1]}]}";
+        // Arrange - https://datatracker.ietf.org/doc/html/rfc7946#appendix-A.7
+        const string geometryCollection = "{\"type\":\"GeometryCollection\",\"geometries\":[{\"type\":\"MultiPolygon\",\"coordinates\":[[[[102.0,2.0],[103.0,2.0],[103.0,3.0],[102.0,2.0]]]]},{\"type\":\"Point\",\"coordinates\":[100.0,20.2,10.1]}]}";
         var expected = new GeometryCollection
         {
             Geometries = new List<Geometry>
             {
                 new MultiPolygon
                 {
-                    Coordinates = new List<List<List<double>>>
+                    Coordinates = new List<List<List<List<double>>>>
                     {
-                        new ()
+                        new()
                         {
-                            new List<double> { 100.0, 20.2, 10.1 }
+                            new() { new(){102.0, 2.0}, new(){103.0, 2.0}, new(){103.0, 3.0}, new(){102.0, 2.0} }
                         }
                     }
                 },
@@ -269,7 +385,7 @@ public class GeometrySerialisationTests
         };
 
         // Act
-        var result = JsonConvert.DeserializeObject<GeometryCollection>(multiPolygon, jsonSerializerSettings);
+        var result = JsonConvert.DeserializeObject<GeometryCollection>(geometryCollection, jsonSerializerSettings);
 
         // Assert
         result.Should().BeEquivalentTo(expected);

--- a/src/IIIF/IIIF.Tests/Serialisation/ManifestSerialisationTests.cs
+++ b/src/IIIF/IIIF.Tests/Serialisation/ManifestSerialisationTests.cs
@@ -222,11 +222,11 @@ public class ManifestSerialisationTests
                             {
                                 new MultiPolygon
                                 {
-                                    Coordinates = new List<List<List<double>>>
+                                    Coordinates = new List<List<List<List<double>>>>
                                     {
                                         new ()
                                         {
-                                            new List<double> { 100.0, 20.2, 10.1 }
+                                            new List<List<double>> { new() { 100.0, 20.2, 10.1 } }
                                         }
                                     }
                                 },

--- a/src/IIIF/IIIF/Presentation/V3/Extensions/NavPlace/LineString.cs
+++ b/src/IIIF/IIIF/Presentation/V3/Extensions/NavPlace/LineString.cs
@@ -7,8 +7,8 @@ public class LineString : Geometry
     public override string Type => nameof(LineString);
     
     /// <summary>
-    /// This is an array of two or more positions.
+    /// This is an array of two or more positions. Each position is [lon, lat, alt?].
     /// </summary>
     [JsonProperty(Order = 2)]
-    public List<double>? Coordinates { get; set; }
+    public List<List<double>>? Coordinates { get; set; }
 }

--- a/src/IIIF/IIIF/Presentation/V3/Extensions/NavPlace/MultiLineString.cs
+++ b/src/IIIF/IIIF/Presentation/V3/Extensions/NavPlace/MultiLineString.cs
@@ -7,8 +7,8 @@ public class MultiLineString : Geometry
     public override string Type => nameof(MultiLineString);
 
     /// <summary>
-    /// This is an array of LineString coordinate arrays.
+    /// This is an array of LineString coordinate arrays. Each LineString is an array of positions [lon, lat, alt?].
     /// </summary>
     [JsonProperty(Order = 2)]
-    public List<List<double>>? Coordinates { get; set; }
+    public List<List<List<double>>>? Coordinates { get; set; }
 }

--- a/src/IIIF/IIIF/Presentation/V3/Extensions/NavPlace/MultiPolygon.cs
+++ b/src/IIIF/IIIF/Presentation/V3/Extensions/NavPlace/MultiPolygon.cs
@@ -7,8 +7,9 @@ public class MultiPolygon : Geometry
     public override string Type => nameof(MultiPolygon);
 
     /// <summary>
-    /// This is an array of Polygon coordinate arrays.
+    /// This is an array of Polygon coordinate arrays. Each Polygon is an array of linear rings;
+    /// each ring is an array of positions [lon, lat, alt?].
     /// </summary>
     [JsonProperty(Order = 2)]
-    public List<List<List<double>>>? Coordinates { get; set; }
+    public List<List<List<List<double>>>>? Coordinates { get; set; }
 }

--- a/src/IIIF/IIIF/Presentation/V3/Extensions/NavPlace/Polygon.cs
+++ b/src/IIIF/IIIF/Presentation/V3/Extensions/NavPlace/Polygon.cs
@@ -7,8 +7,9 @@ public class Polygon : Geometry
     public override string Type => nameof(Polygon);
 
     /// <summary>
-    /// This MUST be an array of linear ring coordinate arrays.
+    /// Array of linear ring coordinate arrays. First ring is the exterior boundary;
+    /// subsequent rings are interior rings (holes). Each ring is an array of positions [lon, lat, alt?].
     /// </summary>
     [JsonProperty(Order = 2)]
-    public List<List<double>>? Coordinates { get; set; }
+    public List<List<List<double>>>? Coordinates { get; set; }
 }


### PR DESCRIPTION
Fixes #91 

The Coordinates property types on four geometry models were misaligned with [RFC 7946](https://datatracker.ietf.org/doc/html/rfc7946#appendix-A), causing deserialization failures on valid GeoJSON payloads. The nesting depth was one level too shallow on each type:

| Type            | Before                                       | After                                                    |
| --------------- | -------------------------------------------- | -------------------------------------------------------- |
| LineString     | List&lt;double&gt;                         | List&lt;List&lt;double&gt;&gt;                         |
| MultiLineString | List&lt;List&lt;double&gt;&gt;             | List&lt;List&lt;List&lt;double&gt;&gt;&gt;             |
| Polygon         | List&lt;List&lt;double&gt;&gt;             | List&lt;List&lt;List&lt;double&gt;&gt;&gt;             |
| MultiPolygon    | List&lt;List&lt;List&lt;double&gt;&gt;&gt; | List&lt;List&lt;List&lt;List&lt;double&gt;&gt;&gt;&gt; |

 A position in GeoJSON is [lon, lat, alt?] — a `List<double>`. Every type builds upward from there: a LineString is an array of positions, a Polygon is an array of linear rings (each ring an array of positions), and so on.

The GeometryConverter required no changes; it delegates to `serializer.Populate()` which handles the corrected types correctly.

Existing tests were also corrected - they were passing with invalid GeoJSON that happened to match the wrong coordinate structure. Two new tests cover the specific failing cases from the issue: a LineString with multiple positions and a Polygon with an interior ring (hole).