### PR TITLE
Stop AdditionalProperties storing read-only props

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -90,6 +90,9 @@ The `.Serialisation` namespace contains a number of custom `JsonConverter` imple
 * `[RequiredOutput]` - used on `IEnumerable<T>` properties. Will output `[]` if collection is empty (default is to omit empty lists).
 * `[CamelCaseEnumAttribute]` - use on an enum property to output value as camelCase (e.g. "MissingCredentials" -> "missingCredentials")
 
+> [!IMPORTANT]
+> The `FromJson<TTarget>` and `AsJson` helpers, detailed below, are the supported serialisation/deserialisation path for this library as there are a number of custom converters wired up this way.
+
 ### Helpers
 
 #### Serialisation

--- a/src/IIIF/IIIF.Tests/Serialisation/AdditionalPropertiesTests.cs
+++ b/src/IIIF/IIIF.Tests/Serialisation/AdditionalPropertiesTests.cs
@@ -318,7 +318,7 @@ public class AdditionalPropertiesTests
             .ToList();
         itemsWithThumbnail.Should().NotBeEmpty();
     }
-
+    
     [Fact]
     public void ManifestDataFileTwo_BilingualLabels_PreservedAfterStrip()
     {
@@ -332,5 +332,50 @@ public class AdditionalPropertiesTests
             .Single(m => m.Id!.Contains("exhibit-10"));
         exhibit10.Label!["en"].Should().Contain("Through the Lens of a Professor");
         exhibit10.Label["nl"].Should().Contain("Door de lens van een professor");
+    }
+    
+    // -------------------------------------------------------------------------
+    // Known-property filtering — read-only overrides must not bleed into AdditionalProperties
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void FromJson_DoesNotStoreKnownProperties_InAdditionalProperties()
+    {
+        // PaintingAnnotation.Motivation is a getter-only computed property. Without the
+        // contract-resolver guard the incoming "motivation" JSON key has nowhere to land
+        // and falls back to AdditionalProperties, causing it to be emitted twice on
+        // re-serialisation.
+        const string json = """
+                            {
+                              "id": "https://example.org/anno/1",
+                              "type": "Annotation",
+                              "motivation": "painting",
+                              "target": "https://example.org/canvas/1"
+                            }
+                            """;
+
+        var anno = json.FromJson<PaintingAnnotation>();
+
+        anno!.AdditionalProperties.Should().NotContainKey("motivation");
+    }
+
+    [Fact]
+    public void AsJson_PaintingAnnotation_MotivationNotDuplicated()
+    {
+        const string json = """
+                            {
+                              "id": "https://example.org/anno/1",
+                              "type": "Annotation",
+                              "motivation": "painting",
+                              "target": "https://example.org/canvas/1"
+                            }
+                            """;
+
+        var roundTripped = json.FromJson<PaintingAnnotation>()!.AsJson();
+
+        var motivationCount = System.Text.RegularExpressions.Regex
+            .Matches(roundTripped, "\"motivation\"")
+            .Count;
+        motivationCount.Should().Be(1, because: "Motivation must not be emitted twice");
     }
 }

--- a/src/IIIF/IIIF.Tests/Serialisation/ManifestDataFileOneTests.cs
+++ b/src/IIIF/IIIF.Tests/Serialisation/ManifestDataFileOneTests.cs
@@ -193,9 +193,8 @@ public class ManifestDataFileOneTests
         firstPage?.AdditionalProperties.Should().BeEmpty();
 
         var firstAnnotation = firstPage?.Items?[0].As<PaintingAnnotation>();
-        firstAnnotation?.AdditionalProperties.Should().ContainSingle();
-        firstAnnotation?.AdditionalProperties.Should().ContainKey("motivation");
-        firstAnnotation?.AdditionalProperties["motivation"]!.ToString().Should().Be("painting");
+        firstAnnotation?.AdditionalProperties.Should().BeEmpty();
+        firstAnnotation?.Motivation.Should().Be("painting");
 
         var specificResource = firstAnnotation?.Body.As<SpecificResource>();
         specificResource?.AdditionalProperties.Should().BeEmpty();

--- a/src/IIIF/IIIF/Serialisation/PrettyIIIFContractResolver.cs
+++ b/src/IIIF/IIIF/Serialisation/PrettyIIIFContractResolver.cs
@@ -1,7 +1,8 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
-using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
 namespace IIIF.Serialisation;
@@ -62,5 +63,33 @@ public class PrettyIIIFContractResolver : CamelCasePropertyNamesContractResolver
         }
 
         return property;
+    }
+
+    // Wraps the [JsonExtensionData] setter so that JSON keys which already correspond to a known property on the type
+    // are not also stored in AdditionalProperties.
+    // Without this, getter-only overrides (e.g. PaintingAnnotation.Motivation) can't be set so end up in
+    // AdditionalProperties during deserialisation, causing the value to be emitted twice on re-serialisation.
+    // Newtonsoft caches the contract per type, so this runs once per type, not per instance.
+    protected override JsonObjectContract CreateObjectContract(Type objectType)
+    {
+        var contract = base.CreateObjectContract(objectType);
+
+        // Nothing to do if the type has no [JsonExtensionData] member.
+        if (contract.ExtensionDataSetter == null) return contract;
+
+        // Get every JSON property name the contract already knows about (already camelCased by the base resolver)
+        var knownPropertyNames = new HashSet<string>(
+            contract.Properties.Select(p => p.PropertyName!),
+            StringComparer.OrdinalIgnoreCase);
+
+        // Update [JsonExtensionData] to drop keys that correspond to a real prop. Meaning only real 'additional' props
+        // are stored in AdditionalProperties.
+        var originalSetter = contract.ExtensionDataSetter;
+        contract.ExtensionDataSetter = (obj, key, value) =>
+        {
+            if (!knownPropertyNames.Contains(key)) originalSetter(obj, key, value);
+        };
+
+        return contract;
     }
 }


### PR DESCRIPTION
Requires that `PrettyIIIFContractResolver` is used but that is the case for a number of other optimisation.

Without this fix, serialised annotations with `"motivation": "painting"` would end up output twice, once from the read-only prop and the other from the AdditionalProperties dictionary.