### PR TITLE
Maintain "features" empty array when serialising

### DIFF
--- a/src/IIIF/IIIF.Tests/Serialisation/GeometrySerialisationTests.cs
+++ b/src/IIIF/IIIF.Tests/Serialisation/GeometrySerialisationTests.cs
@@ -1,5 +1,7 @@
 using System.Collections.Generic;
+using IIIF.Presentation.V3;
 using IIIF.Presentation.V3.Extensions.NavPlace;
+using IIIF.Serialisation;
 using IIIF.Serialisation.Deserialisation;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
@@ -19,6 +21,20 @@ public class GeometrySerialisationTests
             ContractResolver = new CamelCasePropertyNamesContractResolver(),
             Converters = new List<JsonConverter> { new GeometryConverter() }
         };
+    }
+
+    [Fact]
+    public void Serialize_MaintainsEmptyFeatures()
+    {
+        const string input = """
+                                {"type":"Manifest","navPlace":{"type":"FeatureCollection","features":[]}}
+                                """;
+
+        var manifest = input.FromJson<Manifest>();
+        manifest.NavPlace.Features.Should().BeEmpty();
+
+        var result = manifest.AsJson();
+        result.Should().Contain("\"features\": []", "Empty array is maintained");
     }
 
     [Fact]

--- a/src/IIIF/IIIF/Presentation/V3/Extensions/NavPlace/FeatureCollection.cs
+++ b/src/IIIF/IIIF/Presentation/V3/Extensions/NavPlace/FeatureCollection.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using IIIF.Serialisation;
 
 namespace IIIF.Presentation.V3.Extensions.NavPlace;
 
@@ -11,10 +12,11 @@ public class FeatureCollection : JsonLdBase
     
     [JsonProperty(Order = 2)]
     public string Type => nameof(FeatureCollection);
-    
+
     /// <summary>
     /// Represents a spatially bounded area.
     /// </summary>
     [JsonProperty(Order = 3)]
-    public List<Feature>? Features { get; set; }
+    [RequiredOutput]
+    public List<Feature> Features { get; set; } = null!;
 }


### PR DESCRIPTION
Must be an array, according to RFC 7946.

Without the `[RequiredOutput]` a passed empty array was being dropped.