### PR TITLE
Handle painting annotations with multiple bodies

### DIFF
--- a/src/IIIF/IIIF.Tests/Serialisation/Deserialisation/ResourceBaseV3ConverterTests.cs
+++ b/src/IIIF/IIIF.Tests/Serialisation/Deserialisation/ResourceBaseV3ConverterTests.cs
@@ -67,7 +67,7 @@ public class ResourceBaseV3ConverterTests
         var input = "{ \"motivation\": \"painting\", \"id\": \"single\", \"body\": [] }";
 
         JsonConvert.DeserializeObject<ResourceBase>(input, sut)
-            .Should().BeOfType<GeneralAnnotation>("PaintingAnnotation due to motivation and single body");
+            .Should().BeOfType<GeneralAnnotation>("GeneralAnnotation due to motivation and array body");
     }
     
     [Fact]

--- a/src/IIIF/IIIF.Tests/Serialisation/Deserialisation/ResourceBaseV3ConverterTests.cs
+++ b/src/IIIF/IIIF.Tests/Serialisation/Deserialisation/ResourceBaseV3ConverterTests.cs
@@ -34,13 +34,40 @@ public class ResourceBaseV3ConverterTests
     [InlineData("supplementing", typeof(SupplementingDocumentAnnotation))]
     [InlineData("painting", typeof(PaintingAnnotation))]
     [InlineData("classifying", typeof(TypeClassifyingAnnotation))]
-    [InlineData("general", typeof(GeneralAnnotation))]
+    [InlineData("general", typeof(Annotation))]
     public void ReadJson_IdentifiesType_FromMotivation(string type, Type expectedType)
     {
         var input = $"{{ \"motivation\": \"{type}\", \"id\": \"{Guid.NewGuid()}\" }}";
 
         JsonConvert.DeserializeObject<ResourceBase>(input, sut)
             .Should().BeOfType(expectedType, "Concrete type identified from motivation");
+    }
+    
+    [Fact]
+    public void ReadJson_IdentifiesGeneralAnnotation_IfHasBody()
+    {
+        var input = "{ \"motivation\": \"general\", \"id\": \"whatever\", \"body\": [{ \"id\":\"foo\"}] }";
+
+        JsonConvert.DeserializeObject<ResourceBase>(input, sut)
+            .Should().BeOfType<GeneralAnnotation>("Concrete type identified from motivation");
+    }
+    
+    [Fact]
+    public void ReadJson_IdentifiesPaintingAnnotation_SingleBody()
+    {
+        var input = "{ \"motivation\": \"painting\", \"id\": \"single\"}";
+
+        JsonConvert.DeserializeObject<ResourceBase>(input, sut)
+            .Should().BeOfType<PaintingAnnotation>("PaintingAnnotation due to motivation and single body");
+    }
+    
+    [Fact]
+    public void ReadJson_IdentifiesPaintingAnnotation_ArrayBody()
+    {
+        var input = "{ \"motivation\": \"painting\", \"id\": \"single\", \"body\": [] }";
+
+        JsonConvert.DeserializeObject<ResourceBase>(input, sut)
+            .Should().BeOfType<GeneralAnnotation>("PaintingAnnotation due to motivation and single body");
     }
     
     [Fact]

--- a/src/IIIF/IIIF.Tests/Serialisation/Deserialisation/SpecificResourceDeserialisationTests.cs
+++ b/src/IIIF/IIIF.Tests/Serialisation/Deserialisation/SpecificResourceDeserialisationTests.cs
@@ -10,7 +10,7 @@ namespace IIIF.Tests.Serialisation.Deserialisation;
 
 public class SpecificResourceDeserialisationTests
 {
-    private static JsonSerializerSettings DeserializerSettings { get; set; } = new()
+    private static JsonSerializerSettings DeserializerSettings { get; } = new()
     {
         NullValueHandling = NullValueHandling.Ignore,
         ContractResolver = new PrettyIIIFContractResolver(),

--- a/src/IIIF/IIIF/Presentation/V3/Annotation/Annotation.cs
+++ b/src/IIIF/IIIF/Presentation/V3/Annotation/Annotation.cs
@@ -1,5 +1,4 @@
 ﻿using IIIF.Serialisation;
-using Newtonsoft.Json;
 
 namespace IIIF.Presentation.V3.Annotation;
 

--- a/src/IIIF/IIIF/Presentation/V3/Annotation/PaintingAnnotation.cs
+++ b/src/IIIF/IIIF/Presentation/V3/Annotation/PaintingAnnotation.cs
@@ -1,5 +1,12 @@
 ﻿namespace IIIF.Presentation.V3.Annotation;
 
+/// <summary>
+/// An annotation with "painting" motivation and a single body. This is a convenience class for constructing painting
+/// annotations.
+///
+/// Single body is the most common use case for painting annotations, use <see cref="GeneralAnnotation"/> if
+/// multiple bodies are required.
+/// </summary>
 public class PaintingAnnotation : Annotation
 {
     public override string Motivation => Constants.Motivation.Painting;

--- a/src/IIIF/IIIF/Serialisation/Deserialisation/AnnotationV3Converter.cs
+++ b/src/IIIF/IIIF/Serialisation/Deserialisation/AnnotationV3Converter.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using IIIF.Presentation.V3.Annotation;
-using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace IIIF.Serialisation.Deserialisation;
@@ -17,14 +16,7 @@ public class AnnotationV3Converter : ReadOnlyConverter<IAnnotation>
         var jsonObject = JObject.Load(reader);
 
         var motivation = jsonObject["motivation"]?.Value<string>();
-        IAnnotation annotation = motivation switch
-        {
-            Presentation.V3.Constants.Motivation.Painting => new PaintingAnnotation(),
-            Presentation.V3.Constants.Motivation.Supplementing => new SupplementingDocumentAnnotation(),
-            Presentation.V3.Constants.Motivation.Classifying => new TypeClassifyingAnnotation(),
-            _ => jsonObject["body"] is not { HasValues: true } ? new Annotation() : new GeneralAnnotation(motivation)
-        };
-
+        var annotation = MotivationConverter.TryGetAnnotation(jsonObject, motivation!);
         serializer.Populate(jsonObject.CreateReader(), annotation);
         return annotation;
     }

--- a/src/IIIF/IIIF/Serialisation/Deserialisation/Helpers/ResourceDeserialiser.cs
+++ b/src/IIIF/IIIF/Serialisation/Deserialisation/Helpers/ResourceDeserialiser.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using IIIF.Auth.V2;
 using IIIF.ImageApi.V2;
 using IIIF.ImageApi.V3;
@@ -141,15 +140,7 @@ internal class ResourceDeserialiser<T>
         if (jsonObject.ContainsKey("motivation"))
         {
             var motivation = jsonObject["motivation"]?.Value<string>();
-            service = motivation switch
-            {
-                Presentation.V3.Constants.Motivation.Supplementing => new SupplementingDocumentAnnotation() as T,
-                Presentation.V3.Constants.Motivation.Painting => new PaintingAnnotation() as T,
-                Presentation.V3.Constants.Motivation.Classifying => new TypeClassifyingAnnotation() as T,
-                _ => new GeneralAnnotation(motivation) as T
-            };
-            
-            if (service != null) return service;
+            return MotivationConverter.TryGetAnnotation(jsonObject, motivation!) as T;
         }
         
         // Look for consumer-provided mapping
@@ -172,7 +163,7 @@ internal class ResourceDeserialiser<T>
 
         if (!string.IsNullOrEmpty(typeValue))
         {
-            return new Presentation.V3.ExternalService(typeValue) as T;
+            return new ExternalService(typeValue) as T;
         }
         
         if (jsonObject.ContainsKey("id"))

--- a/src/IIIF/IIIF/Serialisation/Deserialisation/MotivationConverter.cs
+++ b/src/IIIF/IIIF/Serialisation/Deserialisation/MotivationConverter.cs
@@ -1,0 +1,31 @@
+﻿using IIIF.Presentation.V3.Annotation;
+using Newtonsoft.Json.Linq;
+
+namespace IIIF.Serialisation.Deserialisation;
+
+/// <summary>
+/// Helper class to convert json to concrete annotation types, used by different converters.
+/// </summary>
+internal static class MotivationConverter
+{
+    public static Annotation TryGetAnnotation(JObject jsonObject, string motivation)
+    {
+        var annotation = motivation switch
+        {
+            Presentation.V3.Constants.Motivation.Painting => GetPaintingAnnotation(jsonObject),
+            Presentation.V3.Constants.Motivation.Supplementing => new SupplementingDocumentAnnotation(),
+            Presentation.V3.Constants.Motivation.Classifying => new TypeClassifyingAnnotation(),
+            _ => jsonObject["body"] is not { HasValues: true } ? new Annotation() : new GeneralAnnotation(motivation) 
+        };
+
+        return annotation;
+    }
+    
+    /// <summary>
+    /// PaintingAnnotation only supports single "body", multiple bodies are rare but possible
+    /// </summary>
+    private static Annotation GetPaintingAnnotation(JObject jsonObject) =>
+        jsonObject.SelectToken("body") is JArray
+            ? new GeneralAnnotation(Presentation.V3.Constants.Motivation.Painting)
+            : new PaintingAnnotation();
+}


### PR DESCRIPTION
Extended handling for deserialising annotations, and extracted to shared location for use by `AnnotationV3Converter` and `ResourceDeserialiser`. We still look at "motivation" to determine the type of annotation but extend the logic for painting

* If `"body"` is an object use `PaintingAnnotation`
* If `"body"` is an array use `GeneralAnnotation`

The key point is that when viewed as plain JSON there is no change.